### PR TITLE
Fix ordering of staffslips names and booleans UIORG-167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.9.0 (IN PROGRESS)
 
 * Increase location fetch limit to 1000. Refs UIORG-137.
+* In service-point form, align sor of print-defaults with staffslip names. UIORG-167.
 
 ## [2.8.1](https://github.com/folio-org/ui-organization/tree/v2.8.1) (2019-03-27)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.8.0...v2.8.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.9.0 (IN PROGRESS)
 
 * Increase location fetch limit to 1000. Refs UIORG-137.
-* In service-point form, align sor of print-defaults with staffslip names. UIORG-167.
+* In service-point form, align sort of print-defaults and staffslip names. UIORG-167.
 
 ## [2.8.1](https://github.com/folio-org/ui-organization/tree/v2.8.1) (2019-03-27)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.8.0...v2.8.1)

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -66,7 +66,7 @@ class ServicePointForm extends React.Component {
   save(data) {
     const { locationIds, staffSlips } = data;
     const { parentResources } = this.props;
-    const allSlips = (parentResources.staffSlips || {}).records || [];
+    const allSlips = orderBy((parentResources.staffSlips || {}).records || [], 'name');
 
     if (locationIds) {
       data.locationIds = locationIds.filter(l => l).map(l => (l.id ? l.id : l));

--- a/src/settings/ServicePoints/ServicePointManager.js
+++ b/src/settings/ServicePoints/ServicePointManager.js
@@ -135,7 +135,7 @@ class ServicePointManager extends React.Component {
   parseInitialValues = (values = {}) => {
     const { resources } = this.props;
     const slipMap = keyBy(values.staffSlips, 'id');
-    const slips = sortBy((resources.staffSlips || {}).records || [],'[name]');
+    const slips = sortBy((resources.staffSlips || {}).records || [], '[name]');
     const staffSlips = slips.map(({ id }) => {
       const { printByDefault } = (slipMap[id] || {});
       return printByDefault || isUndefined(printByDefault);

--- a/src/settings/ServicePoints/ServicePointManager.js
+++ b/src/settings/ServicePoints/ServicePointManager.js
@@ -135,7 +135,7 @@ class ServicePointManager extends React.Component {
   parseInitialValues = (values = {}) => {
     const { resources } = this.props;
     const slipMap = keyBy(values.staffSlips, 'id');
-    const slips = (resources.staffSlips || {}).records || [];
+    const slips = sortBy((resources.staffSlips || {}).records || [],'[name]');
     const staffSlips = slips.map(({ id }) => {
       const { printByDefault } = (slipMap[id] || {});
       return printByDefault || isUndefined(printByDefault);


### PR DESCRIPTION
  In the service points form, the setting of print-default booleans
  for staff-slips is effectively done by position and relies
  on the ordering of the booleans being the same as the ordering of
  the staffslips names. This commit aims to ensure, they are ordered
  the same (by staffslip name).