### PR TITLE
use correct permission names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-organization
 
+## 2.10.0 (IN PROGRESS)
+
+* Bug fix: use correct permission names. Fixes UIORG-172.
+
 ## [2.9.1](https://github.com/folio-org/ui-organization/tree/v2.9.1) (2019-05-20)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.9.0...v2.9.1)
 

--- a/src/settings/LocationLocations/LocationForm.js
+++ b/src/settings/LocationLocations/LocationForm.js
@@ -186,7 +186,7 @@ class LocationForm extends React.Component {
     return (
       <PaneMenu>
         {edit &&
-          <IfPermission perm="settings.organization.enabled">
+          <IfPermission perm="settings.tenant-settings.enabled">
             <Button
               id="clickable-delete-location"
               buttonStyle="danger"
@@ -289,7 +289,7 @@ class LocationForm extends React.Component {
     const { stripes, handleSubmit, initialValues, locationResources, intl: { formatMessage } } = this.props;
     const loc = initialValues || {};
     const { confirmDelete, sections } = this.state;
-    const disabled = !stripes.hasPerm('settings.organization.enabled');
+    const disabled = !stripes.hasPerm('settings.tenant-settings.enabled');
     const name = loc.name || <FormattedMessage id="ui-tenant-settings.settings.location.locations.untitledLocation" />;
     const confirmationMessage = <SafeHTMLMessage id="ui-tenant-settings.settings.location.locations.deleteLocationMessage" values={{ name }} />;
 

--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -398,9 +398,9 @@ class LocationManager extends React.Component {
         rowFilterFunction={this.filterRow}
         nameKey="name"
         permissions={{
-          put: 'settings.organization.enabled',
-          post: 'settings.organization.enabled',
-          delete: 'settings.organization.enabled',
+          put: 'settings.tenant-settings.enabled',
+          post: 'settings.tenant-settings.enabled',
+          delete: 'settings.tenant-settings.enabled',
         }}
       />
     );

--- a/src/settings/ServicePoints/ServicePointManager.js
+++ b/src/settings/ServicePoints/ServicePointManager.js
@@ -13,7 +13,7 @@ class ServicePointManager extends React.Component {
     entries: {
       type: 'okapi',
       records: 'servicepoints',
-      path: 'service-points?limit=1000',
+      path: 'service-points?query=cql.allRecords=1 sortby name&limit=1000',
       resourceShouldRefresh: true,
       POST: {
         path: 'service-points'
@@ -167,9 +167,9 @@ class ServicePointManager extends React.Component {
         asyncValidate={this.asyncValidate}
         nameKey="name"
         permissions={{
-          put: 'settings.organization.enabled',
-          post: 'settings.organization.enabled',
-          delete: 'settings.organization.enabled',
+          put: 'settings.tenant-settings.enabled',
+          post: 'settings.tenant-settings.enabled',
+          delete: 'settings.tenant-settings.enabled',
         }}
       />
     );


### PR DESCRIPTION
Permissions were renamed when the module was renamed but we missed this
in a few places.

Fixes [UIORG-172](https://issues.folio.org/browse/UIORG-172)