### PR TITLE
UIOR-296 Make the acq addresses retain line breaks

### DIFF
--- a/src/settings/Addresses.css
+++ b/src/settings/Addresses.css
@@ -1,0 +1,3 @@
+.addressWrapper {
+  white-space: pre-line;
+}

--- a/src/settings/Addresses.js
+++ b/src/settings/Addresses.js
@@ -10,6 +10,8 @@ import { Field } from 'redux-form';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { TextArea, TextField } from '@folio/stripes/components';
 
+import css from './Addresses.css';
+
 const moduleName = 'TENANT';
 const configName = 'addresses';
 
@@ -50,6 +52,9 @@ const columnMapping = {
   address: <FormattedMessage id="ui-tenant-settings.settings.addresses.address" />,
 };
 const objectLabel = <FormattedMessage id="ui-tenant-settings.settings.addresses.label" />;
+const formatter = {
+  address: item => (<div className={css.addressWrapper}>{item.address}</div>),
+};
 
 class Addresses extends Component {
   static manifest = Object.freeze({
@@ -145,6 +150,7 @@ class Addresses extends Component {
         sortby="name"
         preCreateHook={this.onCreate}
         preUpdateHook={this.onUpdate}
+        formatter={formatter}
       />
     );
   }


### PR DESCRIPTION
## Purpose
Make the acquisitions addresses retain line breaks
https://issues.folio.org/browse/UIOR-296
## Approach
add property `white-space: pre-line` to address block
## Screenshot
![uior296](https://user-images.githubusercontent.com/43407139/59029523-2bd68980-8867-11e9-8d2a-d250439ebf8e.gif)