### PR TITLE
UIORG-81: Prevent input field validation when click cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-tenant-settings
 
+## 2.12.0
+* Bug fix: prevent input field validation when click cancel. Fixes UIORG-81.
+
 ## [2.11.0](https://github.com/folio-org/ui-organization/tree/v2.11.0) (2019-06-13)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.10.0...v2.11.0)
 

--- a/src/settings/LocationCampuses.js
+++ b/src/settings/LocationCampuses.js
@@ -5,8 +5,19 @@ import {
   injectIntl,
   intlShape,
 } from 'react-intl';
+
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { Select } from '@folio/stripes/components';
+
+const visibleFields = [
+  'name',
+  'code',
+];
+const columnMapping = {
+  name: <FormattedMessage id="ui-tenant-settings.settings.location.campuses.campus" />,
+  code: <FormattedMessage id="ui-tenant-settings.settings.location.code" />,
+};
+const objectLabel = <FormattedMessage id="ui-tenant-settings.settings.location.locations" />;
 
 class LocationCampuses extends React.Component {
   static manifest = {
@@ -131,12 +142,9 @@ class LocationCampuses extends React.Component {
         rowFilterFunction={(row) => row.institutionId === this.state.institutionId}
         label={this.props.intl.formatMessage({ id: 'ui-tenant-settings.settings.location.campuses' })}
         labelSingular={this.props.intl.formatMessage({ id: 'ui-tenant-settings.settings.location.campuses.campus' })}
-        objectLabel={<FormattedMessage id="ui-tenant-settings.settings.location.locations" />}
-        visibleFields={['name', 'code']}
-        columnMapping={{
-          name: <FormattedMessage id="ui-tenant-settings.settings.location.campuses.campus" />,
-          code: <FormattedMessage id="ui-tenant-settings.settings.location.code" />,
-        }}
+        objectLabel={objectLabel}
+        visibleFields={visibleFields}
+        columnMapping={columnMapping}
         formatter={{ numberOfObjects: this.numberOfObjectsFormatter }}
         nameKey="group"
         id="campuses"

--- a/src/settings/LocationInstitutions.js
+++ b/src/settings/LocationInstitutions.js
@@ -8,6 +8,18 @@ import {
 
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
+import fieldComponents from '../util/fieldComponents';
+
+const visibleFields = [
+  'name',
+  'code',
+];
+const columnMapping = {
+  name: <FormattedMessage id="ui-tenant-settings.settings.location.institutions.institution" />,
+  code: <FormattedMessage id="ui-tenant-settings.settings.location.code" />,
+};
+const objectLabel = <FormattedMessage id="ui-tenant-settings.settings.location.locations" />;
+
 class LocationInstitutions extends React.Component {
   static manifest = Object.freeze({
     locationsPerInstitution: {
@@ -77,12 +89,10 @@ class LocationInstitutions extends React.Component {
         records="locinsts"
         label={this.props.intl.formatMessage({ id: 'ui-tenant-settings.settings.location.institutions' })}
         labelSingular={this.props.intl.formatMessage({ id: 'ui-tenant-settings.settings.location.institutions.institution' })}
-        objectLabel={<FormattedMessage id="ui-tenant-settings.settings.location.locations" />}
-        visibleFields={['name', 'code']}
-        columnMapping={{
-          name: <FormattedMessage id="ui-tenant-settings.settings.location.institutions.institution" />,
-          code: <FormattedMessage id="ui-tenant-settings.settings.location.code" />,
-        }}
+        objectLabel={objectLabel}
+        visibleFields={visibleFields}
+        columnMapping={columnMapping}
+        fieldComponents={fieldComponents}
         formatter={formatter}
         nameKey="name"
         id="institutions"

--- a/src/settings/LocationLibraries.js
+++ b/src/settings/LocationLibraries.js
@@ -6,9 +6,19 @@ import {
   injectIntl,
   intlShape,
 } from 'react-intl';
+
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { Select } from '@folio/stripes/components';
 
+const visibleFields = [
+  'name',
+  'code',
+];
+const columnMapping = {
+  name: <FormattedMessage id="ui-tenant-settings.settings.location.libraries.library" />,
+  code: <FormattedMessage id="ui-tenant-settings.settings.location.code" />,
+};
+const objectLabel = <FormattedMessage id="ui-tenant-settings.settings.location.locations" />;
 
 class LocationLibraries extends React.Component {
   static manifest = Object.freeze({
@@ -178,12 +188,9 @@ class LocationLibraries extends React.Component {
         rowFilterFunction={(row) => row.campusId === campusId}
         label={this.props.intl.formatMessage({ id: 'ui-tenant-settings.settings.location.libraries' })}
         labelSingular={this.props.intl.formatMessage({ id: 'ui-tenant-settings.settings.location.libraries.library' })}
-        objectLabel={<FormattedMessage id="ui-tenant-settings.settings.location.locations" />}
-        visibleFields={['name', 'code']}
-        columnMapping={{
-          name: <FormattedMessage id="ui-tenant-settings.settings.location.libraries.library" />,
-          code: <FormattedMessage id="ui-tenant-settings.settings.location.code" />,
-        }}
+        objectLabel={objectLabel}
+        visibleFields={visibleFields}
+        columnMapping={columnMapping}
         formatter={formatter}
         nameKey="group"
         id="libraries"

--- a/src/util/fieldComponents.js
+++ b/src/util/fieldComponents.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Field } from 'redux-form';
+
+import { TextField } from '@folio/stripes/components';
+
+function handlePreventDefault(event) {
+  const { relatedTarget } = event;
+
+  if (relatedTarget && relatedTarget.getAttribute('id') && relatedTarget.getAttribute('id').includes('cancel')) {
+    event.preventDefault();
+  }
+}
+
+const fieldComponents = {
+  name: ({ fieldProps, name }) => {
+    return (
+      <Field
+        {...fieldProps}
+        component={TextField}
+        fullWidth
+        autoFocus
+        placeholder={name}
+        onBlur={handlePreventDefault}
+      />
+    );
+  },
+  code: ({ fieldProps, name }) => {
+    return (
+      <Field
+        {...fieldProps}
+        component={TextField}
+        fullWidth
+        placeholder={name}
+      />
+    );
+  },
+};
+
+export default fieldComponents;

--- a/test/bigtest/interactors/location-institutions.js
+++ b/test/bigtest/interactors/location-institutions.js
@@ -1,0 +1,14 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
+
+@interactor class InstitutionsInteractor {
+  editRow = scoped('[class*="editListRow"]');
+  newButton = new ButtonInteractor('#clickable-add-institutions');
+  cancelButton = new ButtonInteractor('#clickable-cancel-institutions-0');
+}
+
+export default new InstitutionsInteractor();

--- a/test/bigtest/tests/location-institutions-test.js
+++ b/test/bigtest/tests/location-institutions-test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+
+import setupApplication from '../helpers/setup-application';
+import institutions from '../interactors/location-institutions';
+
+describe('LocationInstitutions', () => {
+  setupApplication();
+
+  describe('when button "New" is clicked', () => {
+    beforeEach(async function () {
+      this.visit('/settings/tenant-settings/location-institutions');
+
+      await institutions.newButton.click();
+    });
+
+    it('new editable row is present', () => {
+      expect(institutions.editRow.isPresent).to.be.true;
+    });
+
+    it('cancel button is present', () => {
+      expect(institutions.cancelButton).to.exist;
+    });
+
+    describe('when button "Cancel" is clicked', () => {
+      beforeEach(async function () {
+        await institutions.cancelButton.click();
+      });
+
+      it('new editable row is not present', () => {
+        expect(institutions.editRow.isPresent).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Purpose
Prevent input field validation when click cancel according to [story UIORG-81](https://issues.folio.org/browse/UIORG-81).

**Before**


![Behavior_Before](https://user-images.githubusercontent.com/49517355/59441382-29dd6f00-8e01-11e9-86ed-2d2139b70696.gif)

**After**

![Behavior_After](https://user-images.githubusercontent.com/49517355/59441578-7b85f980-8e01-11e9-9d8c-4639b4024a55.gif)
