### PR TITLE
UITEN-43 retrieve additional locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove unnecessary permissions. Refs UITEN-7, UIORG-150.
 * Refactor location locations functionality to get rid of EntryManager usage. Refs UIORG-142.
+* Retrieve all locations and staff-slips when viewing service points. Fixes UITEN-43.
 
 ## [2.11.0](https://github.com/folio-org/ui-organization/tree/v2.11.0) (2019-06-13)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.10.0...v2.11.0)

--- a/src/settings/ServicePoints/ServicePointDetail.js
+++ b/src/settings/ServicePoints/ServicePointDetail.js
@@ -52,8 +52,9 @@ class ServicePointDetail extends React.Component {
     if (state.servicePointId !== id) {
       parentMutator.locations.reset();
       if (id) {
-        const query = `(servicePointIds=${id})`;
-        parentMutator.locations.GET({ params: { query } });
+        const query = `(servicePointIds=${id}) sortby name`;
+        const limit = '1000';
+        parentMutator.locations.GET({ params: { query, limit } });
       }
       return { servicePointId: id };
     }

--- a/src/settings/ServicePoints/ServicePointManager.js
+++ b/src/settings/ServicePoints/ServicePointManager.js
@@ -43,6 +43,10 @@ class ServicePointManager extends React.Component {
       type: 'okapi',
       records: 'staffSlips',
       path: 'staff-slips-storage/staff-slips',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '1000',
+      },
     },
   });
 


### PR DESCRIPTION
When retrieving the locations related to a service-point, retrieve up to
1,000 instead of the default, 10.

Fixes [UITEN-43](https://issues.folio.org/browse/UITEN-43)