### PR TITLE
UITEN-44 restore settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
         "displayName": "UI: Tenant-settings module is enabled"
       },
       {
+        "permissionName": "settings.tenant-settings.enabled",
+        "displayName": "Settings (tenant): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ],
+      },
+      {
         "permissionName": "ui-tenant-settings.settings.addresses",
         "displayName": "Settings (tenant): Can manage tenant addresses",
         "subPermissions": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "displayName": "Settings (tenant): display list of settings pages",
         "subPermissions": [
           "settings.enabled"
-        ],
+        ]
       },
       {
         "permissionName": "ui-tenant-settings.settings.addresses",


### PR DESCRIPTION
Access to tenant settings was inadvertently removed in #31. We don't
need `settings.tenant-settings.enabled` to be a visible permission, but we do
need it to be present so that stripes-core will discover that this
module has settings.

Refs [UITEN-44](https://issues.folio.org/browse/UITEN-44)