### PR TITLE
UITEN-54: Fix the flashing of staff slips checkboxes after hitting sa…

### DIFF
--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { cloneDeep, unset, orderBy } from 'lodash';
+import { cloneDeep, unset, orderBy, get } from 'lodash';
 import {
   FormattedMessage,
   injectIntl,
@@ -63,10 +63,18 @@ class ServicePointForm extends React.Component {
     };
   }
 
+  transformStaffSlipsData = (staffSlips) => {
+    const currentSlips = get(this.props, 'parentResources.staffSlips.records', []);
+    const allSlips = orderBy(currentSlips, 'name');
+
+    return staffSlips.map((printByDefault, index) => {
+      const { id } = allSlips[index];
+      return { id, printByDefault };
+    });
+  }
+
   save(data) {
     const { locationIds, staffSlips } = data;
-    const { parentResources } = this.props;
-    const allSlips = orderBy((parentResources.staffSlips || {}).records || [], 'name');
 
     if (locationIds) {
       data.locationIds = locationIds.filter(l => l).map(l => (l.id ? l.id : l));
@@ -76,13 +84,12 @@ class ServicePointForm extends React.Component {
       unset(data, 'holdShelfExpiryPeriod');
     }
 
-    data.staffSlips = staffSlips.map((printByDefault, index) => {
-      const { id } = allSlips[index];
-      return { id, printByDefault };
-    });
-
     unset(data, 'location');
-    this.props.onSave(data);
+
+    this.props.onSave({
+      ...data,
+      staffSlips: this.transformStaffSlipsData(staffSlips)
+    });
   }
 
   addFirstMenu() {


### PR DESCRIPTION
https://issues.folio.org/browse/UITEN-54

## Purpose
Avoid resetting of the staff slip checkboxes state to checked state after hitting save button on service point edit/create pages. After hitting of the save button form data in Redux state changes from array of the booleans format to array of the objects. Objects considers like "true" boolean value. That's why checkboxes marks as checked after every form submit action .

## Approach
Keep one data format inside form for staff slips(checkboxes). Avoid mutation of the form data in onSave callback

## Screenshots
Previous behavior
![2019-09-12 17 25 44](https://user-images.githubusercontent.com/43621626/64792686-7a8c7180-d582-11e9-9958-31d29b618381.gif)

Current
![2019-09-12 17 29 00](https://user-images.githubusercontent.com/43621626/64793031-0a322000-d583-11e9-9d3f-44bd00da46ea.gif)
