### PR TITLE
UITEN-61: Fix the impact of the API change as per MODINVSTOR-315 for ui-tenant-settings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "route": "/tenant-settings",
     "okapiInterfaces": {
       "configuration": "2.0",
-      "location-units": "1.1",
+      "location-units": "2.0",
       "locations": "3.0",
       "login-saml": "1.0",
       "service-points": "3.0"


### PR DESCRIPTION
"location-units" version bumped to '2.0'