### PR TITLE
UITEN-53 provide link to session-locale settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-tenant-settings
 
+## 2.14.0 (IN PROGRESS)
+
+* Provide a link to session-locale settings from tenant-locale-settings. Refs UITEN-53.
+
 ## [2.13.1](https://github.com/folio-org/ui-organization/tree/v2.13.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.13.0...v2.13.1)
 

--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
+
+import { IfPermission } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
-import { Col, Row, Select, CurrencySelect } from '@folio/stripes/components';
+import { Button, Col, Row, Select, CurrencySelect } from '@folio/stripes/components';
 import timezones from '../util/timezones';
 
 const timeZonesList = timezones.map(timezone => (
@@ -96,6 +98,20 @@ class Locale extends React.Component {
         onBeforeSave={this.beforeSave}
         onAfterSave={this.setLocaleSettings}
       >
+        <IfPermission perm="ui-developer.settings.locale">
+          <Row>
+            <Col xs={12} id="select-locale">
+              <p>
+                <FormattedMessage id="ui-tenant-settings.settings.locale.localeWarning" values={{ label: <FormattedMessage id="ui-tenant-settings.settings.locale.changeSessionLocale" /> }} />
+              </p>
+              <div>
+                <Button to="/settings/developer/locale">
+                  <FormattedMessage id="ui-tenant-settings.settings.locale.changeSessionLocale" />
+                </Button>
+              </div>
+            </Col>
+          </Row>
+        </IfPermission>
         <Row>
           <Col xs={12} id="select-locale">
             <div>

--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -100,7 +100,7 @@ class Locale extends React.Component {
       >
         <IfPermission perm="ui-developer.settings.locale">
           <Row>
-            <Col xs={12} id="select-locale">
+            <Col xs={12}>
               <p>
                 <FormattedMessage id="ui-tenant-settings.settings.locale.localeWarning" values={{ label: <FormattedMessage id="ui-tenant-settings.settings.locale.changeSessionLocale" /> }} />
               </p>

--- a/test/bigtest/helpers/turn-off-warnings.js
+++ b/test/bigtest/helpers/turn-off-warnings.js
@@ -1,0 +1,15 @@
+const warn = console.warn;
+const blacklist = [
+  /componentWillReceiveProps has been renamed/,
+  /componentWillUpdate has been renamed/,
+  /componentWillMount has been renamed/,
+];
+
+export default function turnOffWarnings() {
+  console.warn = function (...args) {
+    if (blacklist.some(rx => rx.test(args[0]))) {
+      return;
+    }
+    warn.apply(console, args);
+  };
+}

--- a/test/bigtest/index.js
+++ b/test/bigtest/index.js
@@ -1,5 +1,7 @@
 import 'babel-polyfill';
+import turnOffWarnings from './helpers/turn-off-warnings';
 
+turnOffWarnings();
 // require all modules ending in "-test" from the current directory and
 // all subdirectories
 const requireTest = require.context('./tests/', true, /-test/);

--- a/test/bigtest/tests/language-and-localization-test.js
+++ b/test/bigtest/tests/language-and-localization-test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import setupApplication from '../helpers/setup-application';
 import LanguageAndLocalization from '../interactors/language-and-localization';
+import translations from '../../../translations/ui-tenant-settings/en';
 
 describe('Language and localization', () => {
   setupApplication({ scenarios: ['language-and-localization'] });
@@ -12,8 +13,9 @@ describe('Language and localization', () => {
   });
 
   it('should be present', () => {
-    expect(lal.title).to.equal('Language and localization');
+    expect(lal.title).to.equal(translations['settings.language.label']);
   });
+
   describe('Test primary currency', () => {
     beforeEach(async function () {
       await lal.selectCurrency.selectAndBlur('Canadian Dollar (CAD)');

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -15,7 +15,7 @@
   "settings.localization": "Locale (for language display, date format etc.)",
   "settings.timeZonePicker": "Time zone (time zone used when showing date time information)",
   "settings.primaryCurrency": "Primary currency (for currency symbol to display)",
-  "settings.locale.localeWarning": "The settings on this page will PERMANENTLY change the locale (including language display, date format, and number format) for all users. You are strongly discouraged from changing the locale here unless you are absolutely certain it is the correction action. To TEMPORARILY change the locale for your session only, click the \"{label}\" button instead.",
+  "settings.locale.localeWarning": "The settings on this page will PERMANENTLY change the locale (including language display, date format, and number format) for all users. You are strongly discouraged from changing the locale here unless you are absolutely certain it is the correct action. To TEMPORARILY change the locale for your session only, click the \"{label}\" button instead.",
   "settings.locale.changeSessionLocale": "Change session locale",
   "settings.updated": "Settings were successfully updated.",
 

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -15,6 +15,8 @@
   "settings.localization": "Locale (for language display, date format etc.)",
   "settings.timeZonePicker": "Time zone (time zone used when showing date time information)",
   "settings.primaryCurrency": "Primary currency (for currency symbol to display)",
+  "settings.locale.localeWarning": "The settings on this page will PERMANENTLY change the locale (including language display, date format, and number format) for all users. You are strongly discouraged from changing the locale here unless you are absolutely certain it is the correction action. To TEMPORARILY change the locale for your session only, click the \"{label}\" button instead.",
+  "settings.locale.changeSessionLocale": "Change session locale",
   "settings.updated": "Settings were successfully updated.",
 
   "settings.saml.validate.fillIn": "Please fill this in to continue",


### PR DESCRIPTION
Provide a link from the tenant-locale page to the ui-developer
session-locale page in the hope that folks will use that instead.

Refs [UITEN-53](https://issues.folio.org/browse/UITEN-53)