### PR TITLE
UITEN-83: Update stripes to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## 2.15.0 (IN PROGRESS)
 
+* Update "stripes" to 'v3.0.0', "stripes-components" to '6.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UITEN-83.
+
 ## [2.14.0](https://github.com/folio-org/ui-organization/tree/v2.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.13.1...v2.14.0)
 
 * Update "location-units" version bumped to '2.0'. Refs UITEN-61.
 * Provide a link to session-locale settings from tenant-locale-settings. Refs UITEN-53.
 * Fix new addresses saving. Refs UIOR-459.
-* Update "stripes" to 'v3.0.0', "stripes-components" to '6.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UITEN-83.
 
 ## [2.13.1](https://github.com/folio-org/ui-organization/tree/v2.13.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.13.0...v2.13.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Update "location-units" version bumped to '2.0'. Refs UITEN-61.
 * Provide a link to session-locale settings from tenant-locale-settings. Refs UITEN-53.
 * Fix new addresses saving. Refs UIOR-459.
-* Update "stripes" to 'v3.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UITEN-83.
+* Update "stripes" to 'v3.0.0', "stripes-components" to '6.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UITEN-83.
 
 ## [2.13.1](https://github.com/folio-org/ui-organization/tree/v2.13.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.13.0...v2.13.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update "location-units" version bumped to '2.0'. Refs UITEN-61.
 * Provide a link to session-locale settings from tenant-locale-settings. Refs UITEN-53.
 * Fix new addresses saving. Refs UIOR-459.
+* Update "stripes" to 'v3.0.0', "stripes-core" to '4.0.0' and "react-intl" to '2.9.0'. Refs UITEN-83.
 
 ## [2.13.1](https://github.com/folio-org/ui-organization/tree/v2.13.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.13.0...v2.13.1)

--- a/package.json
+++ b/package.json
@@ -147,9 +147,9 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes-components": "^5.7.0",
-    "@folio/stripes": "^2.10.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.8.0",
-    "@folio/stripes-core": "^3.6.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -165,12 +165,12 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "query-string": "^6.8.1",
-    "react-intl": "^2.3.0",
+    "react-intl": "^2.9.0",
     "react-router-dom": "^4.1.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.10.0",
+    "@folio/stripes": "^3.0.0",
     "react": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes-components": "^5.7.0",
+    "@folio/stripes-components": "^6.0.0",
     "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.8.0",
     "@folio/stripes-core": "^4.0.0",
@@ -156,6 +156,7 @@
     "eslint": "^5.5.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
+    "react-router-dom": "^4.1.1",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "sinon": "^7.2.2"
@@ -165,12 +166,12 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "query-string": "^6.8.1",
-    "react-intl": "^2.9.0",
-    "react-router-dom": "^4.1.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",
+    "react-intl": "^2.9.0",
+    "react-router-dom": "^4.1.1",
     "react": "*"
   }
 }


### PR DESCRIPTION
## Purpose:
Update 
`stripes` to `v3.0.0`, 
`stripes-core` to `4.0.0`,
`react-intl` to `2.9.0`

## Task:
[UITEN-83](https://issues.folio.org/browse/UITEN-83)

## Note:
Please, update your core `package.json`:
```javascript
"dependencies": {
    "@folio/stripes": "^3.0.0"
  },
  "resolutions": {
    "@folio/stripes": "^3.0.0"
  }
```