### PR TITLE
restore delete-button element-ids

### DIFF
--- a/src/settings/LocationLocations/LocationDetail.js
+++ b/src/settings/LocationLocations/LocationDetail.js
@@ -159,6 +159,7 @@ class LocationDetail extends React.Component {
       <Button
         data-test-edit-location-menu-button
         buttonStyle="dropdownItem"
+        id="clickable-edit-location"
         onClick={() => {
           this.props.onEdit(item);
           onToggle();
@@ -171,6 +172,7 @@ class LocationDetail extends React.Component {
       <Button
         data-test-clone-location-menu-button
         buttonStyle="dropdownItem"
+        id="clickable-copy-location"
         onClick={() => {
           this.props.onClone(item);
           onToggle();
@@ -184,6 +186,7 @@ class LocationDetail extends React.Component {
         <Button
           data-test-delete-location-menu-button
           buttonStyle="dropdownItem"
+          id="clickable-delete-location"
           onClick={() => {
             this.toggleDeleteLocationConfirmation();
             onToggle();

--- a/test/ui-testing/locations.js
+++ b/test/ui-testing/locations.js
@@ -322,8 +322,6 @@ module.exports.test = function locationTest(uiTestCtx) {
           .select('#librarySelect', libraryId)
           .wait('#locations-list [role=row] [role=gridcell]')
           .click('#locations-list [role=row] [role=gridcell]')
-          .wait('#clickable-edit-item')
-          .click('#clickable-edit-item')
           .wait('#clickable-delete-location')
           .click('#clickable-delete-location')
           .wait('#clickable-deletelocation-confirmation-confirm')


### PR DESCRIPTION
Restore `id` attributes to the action menu items so we can find them in
tests. Happy tests!

