### PR TITLE
UITEN-81: Provide default `isActive` value for the locations loaded v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugs
 * [UITEN-32](https://issues.folio.org/browse/UITEN-32) Remove hardcoded font sizes
 * [UITEN-72](https://issues.folio.org/browse/UITEN-72) Security update eslint to >= 6.2.1 or eslint-util >= 1.4.1
+* [UITEN-81](https://issues.folio.org/browse/UITEN-81) Provide default `isActive` value for the locations loaded via API
 
 ## [3.0.0](https://github.com/folio-org/ui-organization/tree/v3.0.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v2.13.1...v3.0.0)

--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -310,7 +310,7 @@ class LocationManager extends React.Component {
 
   validate = values => {
     const errors = {};
-    const requiredFields = ['name', 'code', 'discoveryDisplayName', 'institutionId', 'campusId', 'libraryId', 'isActive'];
+    const requiredFields = ['name', 'code', 'discoveryDisplayName', 'institutionId', 'campusId', 'libraryId'];
     requiredFields.forEach(field => {
       if (!values[field]) {
         errors[field] = <FormattedMessage id="stripes-core.label.missingRequiredField" />;
@@ -686,6 +686,11 @@ class LocationManager extends React.Component {
 
     const selectedItem = (selectedId && !adding)
       ? find(contentData, entry => entry.id === selectedId) : defaultEntry;
+
+    // Providing default 'isActive' value is used here when the 'isActive' property is missing in the 'location' loaded via the API.
+    if (selectedItem && selectedItem.isActive === undefined) {
+      selectedItem.isActive = true;
+    }
 
     const initialValues = this.parseInitialValues(selectedItem, cloning);
 


### PR DESCRIPTION
https://issues.folio.org/browse/UITEN-81

## Purpose
When loading `location` via the API and if the `isActive` value is missing in it, the default `isActive` value in `Location Details` pane didn't match the value in `Location Edit Form`.

This fixes that bug by providing default 'isActive' value.