### PR TITLE
UITEN-81: Add 'isActive' property to all 'locations' where it's missing

### DIFF
--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -13,6 +13,7 @@ import {
   isEmpty,
   omit,
   get,
+  forEach,
 } from 'lodash';
 import queryString from 'query-string';
 
@@ -684,13 +685,15 @@ class LocationManager extends React.Component {
     const adding = search.match('layer=add');
     const cloning = search.match('layer=clone');
 
+    // Providing default 'isActive' value is used here when the 'isActive' property is missing in the 'locations' loaded via the API.
+    forEach(contentData, location => {
+      if (location.isActive === undefined) {
+        location.isActive = true;
+      }
+    });
+
     const selectedItem = (selectedId && !adding)
       ? find(contentData, entry => entry.id === selectedId) : defaultEntry;
-
-    // Providing default 'isActive' value is used here when the 'isActive' property is missing in the 'location' loaded via the API.
-    if (selectedItem && selectedItem.isActive === undefined) {
-      selectedItem.isActive = true;
-    }
 
     const initialValues = this.parseInitialValues(selectedItem, cloning);
 


### PR DESCRIPTION
### Purpose
https://issues.folio.org/browse/UITEN-81

Refinement of the functionality implemented by the [80ce58d](https://github.com/folio-org/ui-tenant-settings/commit/80ce58dbcf1e0fe21bedb67ad3002c8ff0892321) in order to provide the 'isActive' property to all 'locations' where it's missing.