### PR TITLE
UITEN-81: Set default isActive property to false if it's missing

### DIFF
--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -687,7 +687,7 @@ class LocationManager extends React.Component {
     // Providing default 'isActive' value is used here when the 'isActive' property is missing in the 'locations' loaded via the API.
     forEach(contentData, location => {
       if (location.isActive === undefined) {
-        location.isActive = true;
+        location.isActive = false;
       }
     });
 


### PR DESCRIPTION
Continued #115 and #118.
### Purpose
As a result of the discussion in the comments to [UITEN-81](https://issues.folio.org/browse/UITEN-81), it was decided to adhere to the following approach:

> When isActive is present and true, the status should be Active. When isActive is (a) present and false or (b) absent, the status should be Inactive.

