### PR TITLE
PERF-62 use == for more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-tenant-settings
 
 ## (4.1.0) IN PROGRESS
+* [PERF-62](https://issues.folio.org/browse/PERF-62) Use more efficient queries.
 
 ## [4.0.0](https://github.com/folio-org/ui-organization/tree/v4.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v3.0.0...v4.0.0)

--- a/src/settings/Plugins/Plugins.js
+++ b/src/settings/Plugins/Plugins.js
@@ -15,7 +15,7 @@ class Plugins extends React.Component {
     settings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module=PLUGINS)',
+      path: 'configurations/entries?query=(module==PLUGINS)',
       POST: {
         path: 'configurations/entries',
       },


### PR DESCRIPTION
Use `==` instead of `=` when possible for more efficient queries.

Refs [PERF-62](https://issues.folio.org/browse/PERF-62)