### PR TITLE
UITEN-108 import supported locales from stripes-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * [UITEN-76](https://issues.folio.org/browse/UITEN-76) Refactor forms to use final-form
 * [UITEN-107](https://issues.folio.org/browse/UITEN-107) Retrieve data for up to 1000 plugins
+* [UITEN-108](https://issues.folio.org/browse/UITEN-108) Import support locales from stripes-core. 
 
 ## [4.0.0](https://github.com/folio-org/ui-organization/tree/v4.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v3.0.0...v4.0.0)

--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, createIntl, createIntlCache } from 'react-intl';
 import { Field } from 'redux-form';
 
-import { IfPermission } from '@folio/stripes/core';
+import { IfPermission, supportedLocales } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 import { Button, Col, Row, Select, CurrencySelect } from '@folio/stripes/components';
 import timezones from '../util/timezones';
@@ -15,28 +15,7 @@ const timeZonesList = timezones.map(timezone => (
   }
 ));
 
-const options = [
-  { value: 'ar', label: '' },
-  { value: 'zh-CN', label: '' },
-  { value: 'zh-TW', label: '' },
-  { value: 'da-DK', label: '' },
-  { value: 'en-GB', label: '' },
-  { value: 'en-SE', label: '' },
-  { value: 'en-US', label: '' },
-  { value: 'fr-FR', label: '' },
-  { value: 'de-DE', label: '' },
-  { value: 'he', label: '' },
-  { value: 'hu-HU', label: '' },
-  { value: 'ja', label: '' },
-  { value: 'it-IT', label: '' },
-  { value: 'pt-BR', label: '' },
-  { value: 'pt-PT', label: '' },
-  { value: 'ru', label: '' },
-  { value: 'es', label: '' },
-  { value: 'es-419', label: '' },
-  { value: 'es-ES', label: '' },
-  { value: 'ur', label: '' },
-];
+const options = supportedLocales.map(k => ({ value: k, label: '' }));
 
 class Locale extends React.Component {
   static propTypes = {


### PR DESCRIPTION
The canonical list of supported locales is now imported from
stripes-core rather than copied locally.

Refs [UITEN-108](https://issues.folio.org/browse/UITEN-108)