### PR TITLE
FOLIO-2727 temporarily disable flakey tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UITEN-76](https://issues.folio.org/browse/UITEN-76) Refactor forms to use final-form
 * [UITEN-107](https://issues.folio.org/browse/UITEN-107) Retrieve data for up to 1000 plugins
 * [UITEN-108](https://issues.folio.org/browse/UITEN-108) Import support locales from stripes-core. 
+* [FOLIO-2727](https://issues.folio.org/browse/FOLIO-2727) Temporarily disable flakey integration tests.
 
 ## [4.0.0](https://github.com/folio-org/ui-organization/tree/v4.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v3.0.0...v4.0.0)

--- a/test/ui-testing/test.js
+++ b/test/ui-testing/test.js
@@ -11,9 +11,10 @@ module.exports.test = function meh(uitestctx) {
   newProxy.test(uitestctx);
 };
 */
-
+/*
 const locations = require('./locations.js');
 
 module.exports.test = function meh(uitestctx) {
   locations.test(uitestctx);
 };
+*/


### PR DESCRIPTION
I love this test. It is my favorite test in all off my nightmare tests.
I love this test the most because it always succeeds when I run it in
isolation and always fails when I run it as part of the suite. This
makes it extra special and extra deserving of my love. NightmareJS and
consistent test results walk hand in hand together like love, marriage,
and ritual infanticide. A test is a test of course, I Jest, and no one
can talk to a test unless, that is, oh hell, unless you spell, your test
like R-T-L. What if the BigTest is not big enough? _He cries_. Writing
more tests in NightmareJS will liquify the nerves of the sentient beings
*it begins*. It is a journey. It is a journey up a river of c͒ͪo͛ͫrruption.
*_He comes_*. It is a journey across the water in search of a m̡adman,
in se̶arch of darkne̸ss, into darkness, into the heart of darkness, it is
darknes̸s̸. My NightmareJS is a waking dream. Goodnight darkness,
goodnight test, goodnight ̕un̨ho͞ly radiańcé destro҉yer of enli̍̈́̂̈́ghtenment.
WE ARE LOST. Goodnight enzymes, goodn̷ight proteinŚ͖̩͇̗̪̏̈́, goodnight little
bowl of m̷̙̲̝͖ͭ̏ͥͮ͟uͮ͏̮̪̝͍̲̖͊̒ͪͩͬ̚̚͜s̴̟̟͙̞̑ͩ͌͝h̨̥̫͎̭ͯ̿̔̀ͅ. HUSH. The end is nigh.

Refs [FOLIO-2727](https://issues.folio.org/browse/FOLIO-2727), [FOLIO-2723](https://issues.folio.org/browse/FOLIO-2723)
