### PR TITLE
Pass required options object to FormatDisplayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [FOLIO-2727](https://issues.folio.org/browse/FOLIO-2727) Temporarily disable flakey integration tests.
 * [UITEN-109](https://issues.folio.org/browse/UITEN-109) Use `label`/`aria-label` correctly for tenant-locale settings
 * [UITEN-112](https://issues.folio.org/browse/UITEN-112) Increment `react-intl` to `^5.8.0`.
+* [UITEN-117](https://issues.folio.org/browse/UITEN-117) Fix Locale page crashes due to react-intl changes affecting the use of `formatDisplayName()`.
 
 ## [4.0.0](https://github.com/folio-org/ui-organization/tree/v4.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v3.0.0...v4.0.0)

--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -58,7 +58,7 @@ class Locale extends React.Component {
       // e.g. given the current locale is `ar` and the keys `ar` and `zh-CN` show:
       //    العربية / العربية
       //    الصينية (الصين) / 中文（中国）
-      locale.label = `${intl.formatDisplayName(locale.value)} / ${locale.intl.formatDisplayName(locale.value)}`;
+      locale.label = `${intl.formatDisplayName(locale.value, { type: 'language' })} / ${locale.intl.formatDisplayName(locale.value, { type: 'language' })}`;
     });
   }
 


### PR DESCRIPTION
## Purpose
A few days ago, FormatJS made the `type` option required on its DisplayNameOptions object. Since their environment/code is typescript, their code can move along assuming it will be there - but in our case it wasn't which caused some ugly crashes when entering a page that rendered a list of locales both ui-developer and ui-tenant-settings were affected, far as I see...

## Approach
Simply adding the display options object with a `type` parameter of `language` resolved the issue.

## Learning
Browser API under the hood holds the options as optional, but all of their examples have something set... It even defaults to 'language' if you pass nothing, but not at the layer of react-intl where the problem resides...

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:


While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
