### PR TITLE
UITEN-115: Make permission names localizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-tenant-settings
 
 ## (6.0.0) IN PROGRESS
+* [UITEN-115](https://issues.folio.org/browse/UITEN-115) Make permission names localizable.
 
 ## [5.0.0](https://github.com/folio-org/ui-organization/tree/v5.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-organization/compare/v4.0.0...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "displayName": "UI: Tenant-settings module is enabled"
       },
       {
-        "permissionName": "ui-tenant-setting.module.enabled",
+        "permissionName": "ui-tenant-settings.module.enabled",
         "subPermissions": [
           "module.tenant-settings.enabled"
         ],
@@ -48,6 +48,13 @@
         "subPermissions": [
           "settings.enabled"
         ]
+      },
+      {
+        "permissionName": "ui-tenant-settings.settings.enabled",
+        "subPermissions": [
+          "settings.tenant-settings.enabled"
+        ],
+        "visible": true
       },
       {
         "permissionName": "ui-tenant-settings.settings.addresses",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "permissionSets": [
       {
         "permissionName": "module.tenant-settings.enabled",
-        "displayName": "UI: Tenant-settings module is enabled"
+        "displayName": "UI: Tenant-settings module is enabled",
+        "visible": false
       },
       {
         "permissionName": "ui-tenant-settings.module.enabled",
@@ -47,7 +48,8 @@
         "displayName": "Settings (tenant): display list of settings pages",
         "subPermissions": [
           "settings.enabled"
-        ]
+        ],
+        "visible": false
       },
       {
         "permissionName": "ui-tenant-settings.settings.enabled",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,13 @@
         "displayName": "UI: Tenant-settings module is enabled"
       },
       {
+        "permissionName": "ui-tenant-setting.module.enabled",
+        "subPermissions": [
+          "module.tenant-settings.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "settings.tenant-settings.enabled",
         "displayName": "Settings (tenant): display list of settings pages",
         "subPermissions": [

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -142,5 +142,15 @@
   "settings.addresses.label": "Addresses",
   "settings.addresses.address": "Address",
   "settings.addresses.name": "Name",
-  "settings.save.error.network": "Record not saved"
+  "settings.save.error.network": "Record not saved",
+
+  "permission.module.enabled": "UI: Tenant-settings module is enabled",
+  "permission.settings.enabled": "Settings (tenant): display list of settings pages",
+  "permission.settings.addresses": "Settings (tenant): Can manage tenant addresses",
+  "permission.settings.key-bindings": "Settings (tenant): Can maintain key bindings",
+  "permission.settings.locale": "Settings (tenant): Can edit language, localization, and currency",
+  "permission.settings.plugins": "Settings (tenant): Can maintain preferred plugins",
+  "permission.settings.sso": "Settings (tenant): Can maintain SSO settings",
+  "permission.settings.location": "Settings (tenant): Can create, edit and remove locations",
+  "permission.settings.servicepoints": "Settings (tenant):  Can create, edit and remove service points"
 }


### PR DESCRIPTION
[[UITEN-115]](https://issues.folio.org/browse/UITEN-115)

## Purpose
Make permission names localizable. 