### PR TITLE
UITEN-123: Disable Download metadata button when url is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (5.1.0) IN PROGRESS
 * [UITEN-115](https://issues.folio.org/browse/UITEN-115) Make permission names localizable.
 * [UITEN-13](https://issues.folio.org/browse/UITEN-13) Build RTL/Jest unit test code coverage.
+* [UITEN-123](https://issues.folio.org/browse/UITEN-123) Disable "Download metadata" button when url is not provided.
 
 ## [5.0.1](https://github.com/folio-org/ui-tenant-settings/tree/v5.0.1) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v5.0.0...v5.0.1)

--- a/src/settings/SSOSettings/SamlForm.js
+++ b/src/settings/SSOSettings/SamlForm.js
@@ -40,6 +40,7 @@ class SamlForm extends React.Component {
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
     initialValues: PropTypes.object.isRequired, // eslint-disable-line react/no-unused-prop-types
+    values: PropTypes.object,
     optionLists: PropTypes.shape({
       identifierOptions: PropTypes.arrayOf(PropTypes.object),
       samlBindingOptions: PropTypes.arrayOf(PropTypes.object),
@@ -57,18 +58,12 @@ class SamlForm extends React.Component {
     label: PropTypes.node,
   };
 
-  constructor(props) {
-    super(props);
-    this.downloadMetadata = this.downloadMetadata.bind(this);
-    this.updateMetadataInvalidated = this.updateMetadataInvalidated.bind(this);
-  }
-
-  updateMetadataInvalidated() {
+  updateMetadataInvalidated = () => {
     this.props.initialValues.metadataInvalidated = false;
     this.forceUpdate();
   }
 
-  downloadMetadata() {
+  downloadMetadata = () => {
     this.props.parentMutator.downloadFile.reset();
     this.props.parentMutator.downloadFile.GET().then((result) => {
       const anchor = document.createElement('a');
@@ -88,6 +83,7 @@ class SamlForm extends React.Component {
       optionLists,
       label,
       validateIdpUrl,
+      values,
     } = this.props;
 
     const identifierOptions = (optionLists.identifierOptions || []).map(i => (
@@ -141,6 +137,7 @@ class SamlForm extends React.Component {
                 <Button
                   id="download-metadata-button"
                   onClick={this.downloadMetadata}
+                  disabled={!values.idpUrl}
                 >
                   <FormattedMessage id="ui-tenant-settings.settings.saml.downloadMetadata" />
                 </Button>
@@ -195,5 +192,6 @@ class SamlForm extends React.Component {
 
 export default stripesFinalForm({
   validate,
+  subscription: { values: true },
   navigationCheck: true,
 })(SamlForm);

--- a/test/bigtest/interactors/sso-settings.js
+++ b/test/bigtest/interactors/sso-settings.js
@@ -14,6 +14,7 @@ import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/i
   save = clickable('button[type="submit"]');
   isLoaded = isPresent('#samlconfig_idpUrl');
   isDownloadMetadataPresent = isPresent('#download-metadata-button');
+  isDownloadMetadataDisabled = isPresent('button:disabled');
 
   idpUrl = new TextFieldInteractor('#fill_idpUrl');
   binding = new SelectInteractor('#select_samlBinding');

--- a/test/bigtest/tests/sso-settings-test.js
+++ b/test/bigtest/tests/sso-settings-test.js
@@ -48,6 +48,16 @@ describe('SSOSettings', () => {
         expect(sso.feedbackError).to.equal(translations['settings.saml.validate.idpUrl']);
       });
     });
+
+    describe('Disable download metadata button', () => {
+      beforeEach(async function () {
+        await sso.idpUrl.fillAndBlur('');
+      });
+
+      it('should disable download metadata button', () => {
+        expect(sso.isDownloadMetadataDisabled).to.equal(true);
+      });
+    });
   });
 
   describe('without permissions', () => {
@@ -57,7 +67,7 @@ describe('SSOSettings', () => {
       permissions: {
         'settings.enabled': true,
         'settings.tenant-settings.enabled': true,
-        'ui-tenant-settings.settings.sso': true
+        'ui-tenant-settings.settings.sso': true,
       },
     });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UITEN-123

Disable Download metadata button when url is not provided.

![download_metadata](https://user-images.githubusercontent.com/63545/99691594-65995100-2a57-11eb-86a5-49f125bbe277.png)
