### PR TITLE
UITEN-123: Only show download button after successful form submission

### DIFF
--- a/src/settings/SSOSettings/SamlForm.js
+++ b/src/settings/SSOSettings/SamlForm.js
@@ -86,6 +86,7 @@ class SamlForm extends React.Component {
       values,
     } = this.props;
 
+
     const identifierOptions = (optionLists.identifierOptions || []).map(i => (
       { id: i.key, label: i.label, value: i.key, selected: initialValues.userProperty === i.key }
     ));
@@ -137,7 +138,7 @@ class SamlForm extends React.Component {
                 <Button
                   id="download-metadata-button"
                   onClick={this.downloadMetadata}
-                  disabled={!values.idpUrl}
+                  disabled={!values.idpUrl || !pristine}
                 >
                   <FormattedMessage id="ui-tenant-settings.settings.saml.downloadMetadata" />
                 </Button>

--- a/src/settings/SSOSettings/SamlForm.js
+++ b/src/settings/SSOSettings/SamlForm.js
@@ -86,7 +86,6 @@ class SamlForm extends React.Component {
       values,
     } = this.props;
 
-
     const identifierOptions = (optionLists.identifierOptions || []).map(i => (
       { id: i.key, label: i.label, value: i.key, selected: initialValues.userProperty === i.key }
     ));


### PR DESCRIPTION
https://issues.folio.org/browse/UITEN-123

This is an additional small change based on the feedback in UITEN-123 to only show download button in cases when the form is saved successfully. 
