### PR TITLE
UITEN-128 do not warn about dangling references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UITEN-13](https://issues.folio.org/browse/UITEN-13) Build RTL/Jest unit test code coverage.
 * [UITEN-123](https://issues.folio.org/browse/UITEN-123) Disable "Download metadata" button when url is not provided.
 * [UITEN-127](https://issues.folio.org/browse/UITEN-127) Add additional permission to location permission set.
+* [UITEN-128](https://issues.folio.org/browse/UITEN-128) Do not warn about dangling references in optional modules.
 
 ## [5.0.1](https://github.com/folio-org/ui-tenant-settings/tree/v5.0.1) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -26,10 +26,6 @@
       "service-points": "3.0",
       "users": "15.0"
     },
-    "optionalOkapiInterfaces": {
-      "course-reserves-storage": "0.2",
-      "reserves-storage": "0.1"
-    },
     "permissionSets": [
       {
         "permissionName": "module.tenant-settings.enabled",

--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -108,18 +108,6 @@ class LocationManager extends React.Component {
       records: 'items',
       accumulate: true,
     },
-    courselistingEntries: {
-      type: 'okapi',
-      path: 'coursereserves/courselistings',
-      records: 'courseListings',
-      accumulate: true,
-    },
-    reserveEntries: {
-      type: 'okapi',
-      path: 'coursereserves/reserves',
-      records: 'reserves',
-      accumulate: true,
-    },
   });
 
   static propTypes = {
@@ -166,14 +154,6 @@ class LocationManager extends React.Component {
         reset: PropTypes.func.isRequired,
       }),
       itemEntries: PropTypes.shape({
-        GET: PropTypes.func.isRequired,
-        reset: PropTypes.func.isRequired,
-      }),
-      courselistingEntries: PropTypes.shape({
-        GET: PropTypes.func.isRequired,
-        reset: PropTypes.func.isRequired,
-      }),
-      reserveEntries: PropTypes.shape({
         GET: PropTypes.func.isRequired,
         reset: PropTypes.func.isRequired,
       }),
@@ -493,18 +473,6 @@ class LocationManager extends React.Component {
       const query = `permanentLocationId=${location.id} or temporaryLocationId=${location.id}`;
       promises.push(mutator.holdingsEntries.GET({ params: { query } }));
       promises.push(mutator.itemEntries.GET({ params: { query } }));
-    }
-
-    // Uses in Course Reserves
-    if (this.props.stripes.hasInterface('course-reserves-storage')) {
-      mutator.courselistingEntries.reset();
-      const query = `locationId=="${location.id}"`;
-      promises.push(mutator.courselistingEntries.GET({ params: { query } }));
-    }
-    if (this.props.stripes.hasInterface('reserves-storage')) {
-      mutator.reserveEntries.reset();
-      const query = `copiedItem.temporaryLocationId=="${location.id}" or copiedItem.permanentLocationId=="${location.id}"`;
-      promises.push(mutator.reserveEntries.GET({ params: { query } }));
     }
 
     return Promise.all(promises)


### PR DESCRIPTION
In short, this PR removes checks for dangling references from
course-reserves, an optional Okapi module. It does so because, as that
module is optional and this one is required, this one sits below it in
the hierarchy of modules and therefore cannot know about the interfaces,
and more importantly, the permissions required to access the endpoints
defined by those interfaces. Thus, even though the queries were
protected correctly by `stripes.ifInterface(...)` conditions, the
queries would still fail because there was no way for the
location-managment pset (`ui-tenant-settings.settings.location`) to
include those permissions.

I feel bad removing this code -- which, to be clear, does its job
perfectly cromulently -- but I have to because there is no way (at least
at present) for it to run with the proper permissions.

Refs [UITEN-128](https://issues.folio.org/browse/UITEN-128)
