### PR TITLE
UITEN-80: Increase query limit for library locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UITEN-123](https://issues.folio.org/browse/UITEN-123) Disable "Download metadata" button when url is not provided.
 * [UITEN-127](https://issues.folio.org/browse/UITEN-127) Add additional permission to location permission set.
 * [UITEN-128](https://issues.folio.org/browse/UITEN-128) Do not warn about dangling references in optional modules.
+* [UITEN-80](https://issues.folio.org/browse/UITEN-80) Fix bug causing some locations to be miscounted in libraries list.
 
 ## [5.0.1](https://github.com/folio-org/ui-tenant-settings/tree/v5.0.1) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v5.0.0...v5.0.1)

--- a/src/settings/LocationLibraries.js
+++ b/src/settings/LocationLibraries.js
@@ -32,7 +32,7 @@ class LocationLibraries extends React.Component {
       path: 'locations',
       params: {
         query: 'cql.allRecords=1 sortby name',
-        limit: '500',
+        limit: '10000',
       },
       accumulate: true,
     },


### PR DESCRIPTION
https://issues.folio.org/browse/UITEN-80

The `locationsPerLibrary` query limit was set rather low, resulting in inaccurate location counts in the library list if the number of locations were too high. Could there be a library system out there with more than 10,000 locations? I hope not.