### PR TITLE
UITEN-166: Rename permission and cleanup unused permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,20 +32,8 @@
     },
     "permissionSets": [
       {
-        "permissionName": "module.tenant-settings.enabled",
-        "displayName": "UI: Tenant-settings module is enabled",
-        "visible": false
-      },
-      {
-        "permissionName": "ui-tenant-settings.module.enabled",
-        "subPermissions": [
-          "module.tenant-settings.enabled"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "settings.tenant-settings.enabled",
-        "displayName": "Settings (tenant): display list of settings pages",
+        "displayName": "Settings (tenant): View",
         "subPermissions": [
           "settings.enabled"
         ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     },
     "permissionSets": [
       {
+        "permissionName": "module.tenant-settings.enabled",
+        "displayName": "UI: Tenant-settings module is enabled",
+        "visible": false
+      },
+      {
         "permissionName": "settings.tenant-settings.enabled",
         "displayName": "Settings (tenant): View",
         "subPermissions": [

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -155,7 +155,7 @@
   "settings.bursarExports.notAvailable": "No plugin available!",
 
   "permission.module.enabled": "UI: Tenant-settings module is enabled",
-  "permission.settings.enabled": "Settings (tenant): display list of settings pages",
+  "permission.settings.enabled": "Settings (tenant): View",
   "permission.settings.addresses": "Settings (tenant): Can manage tenant addresses",
   "permission.settings.key-bindings": "Settings (tenant): Can maintain key bindings",
   "permission.settings.locale": "Settings (tenant): Can edit language, localization, and currency",

--- a/translations/ui-tenant-settings/en_GB.json
+++ b/translations/ui-tenant-settings/en_GB.json
@@ -130,7 +130,7 @@
     "settings.pluginNames.find-erm-usage-data-provider": "Find ERM usage metadata provider",
     "settings.pluginNames.find-finc-metadata-source": "Find finance metadata source",
     "permission.module.enabled": "UI: Tenant-settings module is enabled",
-    "permission.settings.enabled": "Settings (tenant): display list of settings pages",
+    "permission.settings.enabled": "Settings (tenant): View",
     "permission.settings.addresses": "Settings (tenant): Can manage tenant addresses",
     "permission.settings.key-bindings": "Settings (tenant): Can maintain key bindings",
     "permission.settings.locale": "Settings (tenant): Can edit language, localization, and currency",

--- a/translations/ui-tenant-settings/en_SE.json
+++ b/translations/ui-tenant-settings/en_SE.json
@@ -130,7 +130,7 @@
     "settings.pluginNames.find-erm-usage-data-provider": "Find ERM usage metadata provider",
     "settings.pluginNames.find-finc-metadata-source": "Find finance metadata source",
     "permission.module.enabled": "UI: Tenant-settings module is enabled",
-    "permission.settings.enabled": "Settings (tenant): display list of settings pages",
+    "permission.settings.enabled": "Settings (tenant): View",
     "permission.settings.addresses": "Settings (tenant): Can manage tenant addresses",
     "permission.settings.key-bindings": "Settings (tenant): Can maintain key bindings",
     "permission.settings.locale": "Settings (tenant): Can edit language, localization, and currency",

--- a/translations/ui-tenant-settings/en_US.json
+++ b/translations/ui-tenant-settings/en_US.json
@@ -130,7 +130,7 @@
     "settings.pluginNames.find-erm-usage-data-provider": "Find ERM usage metadata provider",
     "settings.pluginNames.find-finc-metadata-source": "Find finance metadata source",
     "permission.module.enabled": "UI: Tenant-settings module is enabled",
-    "permission.settings.enabled": "Settings (tenant): display list of settings pages",
+    "permission.settings.enabled": "Settings (tenant): View",
     "permission.settings.addresses": "Settings (tenant): Can manage tenant addresses",
     "permission.settings.key-bindings": "Settings (tenant): Can maintain key bindings",
     "permission.settings.locale": "Settings (tenant): Can edit language, localization, and currency",


### PR DESCRIPTION
This PR removes two unused permissions:  `module.tenant-settings.enabled` and `ui-tenant-settings.module.enabled` and renames a displayName for `settings.tenant-settings.enabled` permission.

https://issues.folio.org/browse/UITEN-166