### PR TITLE
UITEN-65 disable key-bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (6.1.0) IN PROGRESS
 
+* [UITEN-65](https://issues.folio.org/browse/UITEN-65) Disable key-bindings; it was just a mean tease.
+
 ## [6.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v6.0.0)(2021-03-12)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v5.0.1...v6.0.0)
 * [UITEN-13](https://issues.folio.org/browse/UITEN-13) Build RTL/Jest unit test code coverage.

--- a/package.json
+++ b/package.json
@@ -62,15 +62,6 @@
         "visible": true
       },
       {
-        "permissionName": "ui-tenant-settings.settings.key-bindings",
-        "displayName": "Settings (tenant): Can maintain key bindings",
-        "subPermissions": [
-          "configuration.all",
-          "settings.tenant-settings.enabled"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-tenant-settings.settings.locale",
         "displayName": "Settings (tenant): Can edit language, localization, and currency",
         "subPermissions": [

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -7,7 +7,6 @@ import Addresses from './Addresses';
 import { BursarExports } from './BursarExports';
 import Locale from './Locale';
 import Plugins from './Plugins';
-import Bindings from './Bindings';
 import SSOSettings from './SSOSettings';
 import LocationCampuses from './LocationCampuses';
 import LocationInstitutions from './LocationInstitutions';
@@ -32,12 +31,6 @@ class Organization extends React.Component {
             label: <FormattedMessage id="ui-tenant-settings.settings.addresses.label" />,
             component: Addresses,
             perm: 'ui-tenant-settings.settings.addresses',
-          },
-          {
-            route: 'keys',
-            label: <FormattedMessage id="ui-tenant-settings.settings.bindings.label" />,
-            component: Bindings,
-            perm: 'ui-tenant-settings.settings.key-bindings',
           },
           {
             route: 'locale',


### PR DESCRIPTION
The key-bindings configured here were only functional in Settings >
Developer > Hotkeys test. Rather than providing a useful function, this
was just confusing since it gave the impression that bindings could be
usefully configured, rather than just configured for a POC.

Refs [UITEN-65](https://issues.folio.org/browse/UITEN-65)
