### PR TITLE
Revert "UITEN-180 The Remote storage section is not displayed in the General Information pane"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change history for ui-tenant-settings
 
-## (6.1.1) IN PROGRESS
-* [UITEN-180](https://issues.folio.org/browse/UITEN-180) The Remote storage section is not displayed in the General Information pane
+## (6.2.0) IN PROGRESS
 
 ## [6.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v6.1.0)(2021-06-11)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v6.0.0...v6.1.0)

--- a/src/settings/LocationLocations/RemoteStorageDetails.js
+++ b/src/settings/LocationLocations/RemoteStorageDetails.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -13,7 +13,9 @@ import { useRemoteStorageApi } from './RemoteStorage';
 const RemoteStorageDetails = ({ locationId }) => {
   const { remoteMap, configurations } = useRemoteStorageApi();
 
-  const currentConfig = configurations?.records.find(config => remoteMap[locationId] === config.id);
+  const currentConfig = useMemo(() => {
+    return configurations?.records.find(config => remoteMap[locationId] === config.id);
+  }, [locationId, remoteMap]);
 
   return (
     <>

--- a/src/settings/LocationLocations/remoteStorageDetails.test.js
+++ b/src/settings/LocationLocations/remoteStorageDetails.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { useRemoteStorageApi } from './RemoteStorage';
+
 import RemoteStorageDetails from './RemoteStorageDetails';
 
 const mockConfigurations = {
@@ -15,7 +15,12 @@ const mockRemoteMap = {
   locationWithDetails: 2,
 };
 
-jest.mock('./RemoteStorage');
+jest.mock(
+  './RemoteStorage',
+  () => ({
+    useRemoteStorageApi: () => ({ remoteMap: mockRemoteMap, configurations: mockConfigurations }),
+  }),
+);
 
 const renderRemoteStorageDetails = ({
   locationId
@@ -24,29 +29,11 @@ const renderRemoteStorageDetails = ({
 ));
 
 describe('RemoteStorageDetails', () => {
-  beforeEach(() => {
-    useRemoteStorageApi.mockImplementation(() => ({ remoteMap: mockRemoteMap, configurations: mockConfigurations }));
-  });
-
   it('should render remote storage name and workflow preference if location have them', () => {
     renderRemoteStorageDetails({ locationId: 'locationWithDetails' });
 
     expect(screen.getByText(/remoteStorage/)).toBeVisible();
     expect(screen.getByText(/returning-workflow.title/)).toBeVisible();
-  });
-
-  it('should render name for location with details', () => {
-    renderRemoteStorageDetails({ locationId: 'locationWithDetails' });
-
-    expect(screen.getByText('RS2')).toBeVisible();
-  });
-
-  it('should not render name if state is broken', () => {
-    useRemoteStorageApi.mockImplementation(() => ({ remoteMap: undefined, configurations: undefined }));
-
-    renderRemoteStorageDetails({ locationId: 'locationWithDetails' });
-
-    expect(screen.queryByText('RS2')).not.toBeInTheDocument();
   });
 
   it('should not render workflow preference if location have not it', () => {


### PR DESCRIPTION
Reverts folio-org/ui-tenant-settings#236