### PR TITLE
UITEN-170 include staff-slips access in service-points pset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## (6.1.1) IN PROGRESS
 * [UITEN-180](https://issues.folio.org/browse/UITEN-180) The Remote storage section is not displayed in the General Information pane
+* [UITEN-170](https://issues.folio.org/browse/UITEN-170) Include missing staff-slips permission in service-points pset
 
 ## [6.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v6.1.0)(2021-06-11)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
           "inventory-storage.service-points.item.get",
           "inventory-storage.service-points.item.post",
           "inventory-storage.service-points.item.put",
-          "inventory-storage.service-points.item.delete"
+          "inventory-storage.service-points.item.delete",
+          "circulation-storage.staff-slips.collection.get"
         ],
         "visible": true
       }


### PR DESCRIPTION
## Purpose

Managing service-points requires the ability to view staff-slips in
order to set which slips should be printed by default at any given
service-point. Read permission for staff slips was missing.

## Approach

Add the missing permission.

Refs [UITEN-170](https://issues.folio.org/browse/UITEN-170)
