### PR TITLE
UITEN-188 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* [UITEN-188](https://issues.folio.org/browse/UITEN-188) Upgrade react-intl-safe-html
+
 ## [7.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v7.0.0)(2021-09-31)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v6.1.2...v7.0.0)
 

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "final-form": "^4.18.2",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [UITEN-188](https://issues.folio.org/browse/UITEN-188), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)

