### PR TITLE
UITEN-176: Refactor away from react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * [UITEN-200](https://issues.folio.org/browse/UITEN-200) Language and localization > locale dropdown should be sorted in current locale
+* [UITEN-176](https://issues.folio.org/browse/UITEN-176) Refactor away from `react-intl-safe-html`
 
 ## [7.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v7.0.0)(2021-02-25)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v7.0.1...v7.1.0)

--- a/package.json
+++ b/package.json
@@ -215,7 +215,6 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.1.0",
     "final-form": "^4.18.2",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",

--- a/src/settings/LocationLocations/LocationDetail.js
+++ b/src/settings/LocationLocations/LocationDetail.js
@@ -5,7 +5,6 @@ import {
   get,
   isEmpty,
 } from 'lodash';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import {
   Accordion,
@@ -182,7 +181,7 @@ const LocationDetail = ({
   const locationName =
     loc.name || <FormattedMessage id="ui-tenant-settings.settings.location.locations.untitledLocation" />;
   const confirmationMessage = (
-    <SafeHTMLMessage
+    <FormattedMessage
       id="ui-tenant-settings.settings.location.locations.deleteLocationMessage"
       values={{ name: locationName }}
     />

--- a/src/settings/LocationLocations/LocationManager.js
+++ b/src/settings/LocationLocations/LocationManager.js
@@ -32,7 +32,6 @@ import {
   Layer,
   Callout,
 } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import { SORT_TYPES } from '../../constants';
 import LocationDetail from './LocationDetail';
@@ -510,7 +509,7 @@ class LocationManager extends React.Component {
     if (!this.callout.current) return;
 
     const message = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="stripes-core.successfullyDeleted"
         values={{
           entry: this.entryLabel,


### PR DESCRIPTION
## Purpose
Refactor away from `react-intl-safe-html`.

Issue: [UITEN-176](https://issues.folio.org/browse/UITEN-176)