### PR TITLE
UITEN-172 @folio/eslint-config-stripes@^3.2.1 causes peer-dep inconsi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 * [UITEN-200](https://issues.folio.org/browse/UITEN-200) Language and localization > locale dropdown should be sorted in current locale
 * [UITEN-176](https://issues.folio.org/browse/UITEN-176) Refactor away from `react-intl-safe-html`
+* [UITEN-172](https://issues.folio.org/browse/UITEN-172) @folio/eslint-config-stripes@"^3.2.1" causes peer-dep inconsistency
 
 ## [7.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v7.0.0)(2021-02-25)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v7.0.1...v7.1.0)

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.1",
-    "eslint": "^6.8.0",
+    "eslint": "7.32.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-jest-dom": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.1",
-    "eslint": "7.32.0",
+    "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-jest-dom": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.13.0",
-    "@folio/eslint-config-stripes": "^3.2.1",
+    "@folio/eslint-config-stripes": "^6.2.1",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-components": "^10.0.0",


### PR DESCRIPTION
## Description
@folio/eslint-config-stripes@"^3.2.1" causes peer-dep inconsistency

## Approach
Inside ui-tenant settings, upgraded @folio/eslint-config-stripes version from ^3.2.1 to ^6.2.1 as the older version had peer dependency on eslint@^5.0.0 which was not getting fullfilled

## Issue
[UITEN-172](https://issues.folio.org/browse/UITEN-172)