### PR TITLE
UITEN-251: Service Point Page - Add Confirm Pickup location change popup message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UITEN-233](https://issues.folio.org/browse/UITEN-234) Remember value in Institutions, campuses and libraries dropdown (Settings > Tenant > Locations) when navigating away from page and returning
 * [UITEN-248](https://issues.folio.org/browse/UITEN-248) Improve "Number of locations" on Campuses page
 * [UITEN-249](https://issues.folio.org/browse/UITEN-249) Improve "Number of locations" on Libraries page
+* [UITEN-251](https://issues.folio.org/browse/UITEN-251) Service Point Page - Add Confirm Pickup location change popup message
 
 ## [7.4.0](https://github.com/folio-org/ui-tenant-settings/tree/v7.4.0)(2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v7.3.0...v7.4.0)

--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "@folio/stripes-components": "^11.0.0",
     "@folio/stripes-core": "^9.0.0",
     "@folio/stripes-smart-components": "^8.0.0",
+    "@folio/stripes-testing": "^4.4.0",
     "@formatjs/cli": "^4.2.20",
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.1",

--- a/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.js
+++ b/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.js
@@ -17,6 +17,7 @@ const ConfirmPickupLocationChangeModal = ({
       <Button
         data-testid="confirmButton"
         buttonStyle="primary"
+        autoFocus
         onClick={onConfirm}
       >
         <FormattedMessage id="ui-tenant-settings.settings.confirmPickupLocationChangeModal.button.confirm" />

--- a/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.js
+++ b/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import {
+  Button,
+  Modal,
+  ModalFooter,
+} from '@folio/stripes/components';
+
+const ConfirmPickupLocationChangeModal = ({
+  open,
+  onConfirm,
+  onCancel,
+}) => {
+  const footer = (
+    <ModalFooter>
+      <Button
+        data-testid="confirmButton"
+        buttonStyle="primary"
+        onClick={onConfirm}
+      >
+        <FormattedMessage id="ui-tenant-settings.settings.confirmPickupLocationChangeModal.button.confirm" />
+      </Button>
+      <Button
+        data-testid="cancelButton"
+        onClick={onCancel}
+      >
+        <FormattedMessage id="ui-tenant-settings.settings.confirmPickupLocationChangeModal.button.cancel" />
+      </Button>
+    </ModalFooter>
+  );
+
+  return (
+    <Modal
+      label={<FormattedMessage id="ui-tenant-settings.settings.confirmPickupLocationChangeModal.title" />}
+      open={open}
+      size="small"
+      footer={footer}
+    >
+      <FormattedMessage id="ui-tenant-settings.settings.confirmPickupLocationChangeModal.message" />
+    </Modal>
+  );
+};
+
+ConfirmPickupLocationChangeModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ConfirmPickupLocationChangeModal;

--- a/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.test.js
+++ b/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.test.js
@@ -4,6 +4,8 @@ import {
   fireEvent,
 } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import '../../../test/jest/__mocks__';
 
 import ConfirmPickupLocationChangeModal from './ConfirmPickupLocationChangeModal';
@@ -33,6 +35,12 @@ describe('ConfirmPickupLocationChangeModal', () => {
     render(
       <ConfirmPickupLocationChangeModal {...defaultProps} />
     );
+  });
+
+  it('should render with no axe errors', async () => {
+    await runAxeTest({
+      rootNode: document.body,
+    });
   });
 
   it('should render title', () => {

--- a/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.test.js
+++ b/src/settings/ServicePoints/ConfirmPickupLocationChangeModal.test.js
@@ -1,0 +1,77 @@
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mocks__';
+
+import ConfirmPickupLocationChangeModal from './ConfirmPickupLocationChangeModal';
+
+const defaultProps = {
+  open: true,
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+};
+const testIds = {
+  confirmButton: 'confirmButton',
+  cancelButton: 'cancelButton',
+};
+const messageIds = {
+  title: 'ui-tenant-settings.settings.confirmPickupLocationChangeModal.title',
+  message: 'ui-tenant-settings.settings.confirmPickupLocationChangeModal.message',
+  buttonConfirm: 'ui-tenant-settings.settings.confirmPickupLocationChangeModal.button.confirm',
+  buttonCancel: 'ui-tenant-settings.settings.confirmPickupLocationChangeModal.button.cancel',
+};
+
+describe('ConfirmPickupLocationChangeModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    render(
+      <ConfirmPickupLocationChangeModal {...defaultProps} />
+    );
+  });
+
+  it('should render title', () => {
+    expect(screen.getByText(messageIds.title)).toBeVisible();
+  });
+
+  it('should render message', () => {
+    expect(screen.getByText(messageIds.message)).toBeVisible();
+  });
+
+  describe('Confirm button', () => {
+    it('should render confirm button', () => {
+      expect(screen.getByTestId(testIds.confirmButton)).toBeVisible();
+    });
+
+    it('should render confirm button text', () => {
+      expect(screen.getByText(messageIds.buttonConfirm)).toBeVisible();
+    });
+
+    it('should call onConfirm', () => {
+      fireEvent.click(screen.getByTestId(testIds.confirmButton));
+
+      expect(defaultProps.onConfirm).toHaveBeenCalled();
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('should render cancel button', () => {
+      expect(screen.getByTestId(testIds.cancelButton)).toBeVisible();
+    });
+
+    it('should render cancel button text', () => {
+      expect(screen.getByText(messageIds.buttonCancel)).toBeVisible();
+    });
+
+    it('should call onCancel', () => {
+      fireEvent.click(screen.getByTestId(testIds.cancelButton));
+
+      expect(defaultProps.onCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -1,7 +1,16 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { orderBy } from 'lodash';
-import { FormattedMessage, useIntl } from 'react-intl';
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
+import { Field } from 'react-final-form';
+import { orderBy } from 'lodash';
+
 import {
   Accordion,
   Button,
@@ -19,9 +28,9 @@ import {
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import stripesFinalForm from '@folio/stripes/final-form';
-import { Field } from 'react-final-form';
-
 import { useStripes } from '@folio/stripes/core';
+
+import ConfirmPickupLocationChangeModal from './ConfirmPickupLocationChangeModal';
 import Period from '../../components/Period';
 import LocationList from './LocationList';
 import StaffSlipEditList from './StaffSlipEditList';
@@ -40,6 +49,13 @@ import {
 
 import styles from './ServicePoints.css';
 
+export const SELECTED_PICKUP_LOCATION_VALUE = 'true';
+export const UNSELECTED_PICKUP_LOCATION_VALUE = 'false';
+export const LAYER_EDIT = 'layer=edit';
+export const isConfirmPickupLocationChangeModalShouldBeVisible = (search, value) => (
+  search.includes(LAYER_EDIT) && value === UNSELECTED_PICKUP_LOCATION_VALUE
+);
+
 const ServicePointForm = ({
   initialValues,
   parentResources,
@@ -47,13 +63,17 @@ const ServicePointForm = ({
   pristine,
   submitting,
   form,
+  location: {
+    search,
+  },
   handleSubmit,
-  onCancel
+  onCancel,
 }) => {
   const [sections, setSections] = useState({
     generalSection: true,
     locationSection: true
   });
+  const [isConfirmPickupLocationChangeModal, setIsConfirmPickupLocationChangeModal] = useState(false);
   const stripes = useStripes();
   const intl = useIntl();
   const CViewMetaData = useMemo(() => stripes.connect(ViewMetaData), []);
@@ -82,6 +102,12 @@ const ServicePointForm = ({
       label: intl.formatMessage({ id: ip.label })
     }
   ));
+
+  const onConfirmConfirmPickupLocationChangeModal = () => {
+    form.change('pickupLocation', false);
+    setIsConfirmPickupLocationChangeModal(false);
+  };
+  const onCancelConfirmPickupLocationChangeModal = () => setIsConfirmPickupLocationChangeModal(false);
 
   const renderFirstMenu = () => (
     <PaneMenu>
@@ -172,6 +198,14 @@ const ServicePointForm = ({
         value: item.value
       }
     )));
+  };
+
+  const handleChange = (e) => {
+    if (isConfirmPickupLocationChangeModalShouldBeVisible(search, e.target.value)) {
+      setIsConfirmPickupLocationChangeModal(true);
+    } else {
+      form.change('pickupLocation', e.target.value === SELECTED_PICKUP_LOCATION_VALUE);
+    }
   };
 
   return (
@@ -275,7 +309,7 @@ const ServicePointForm = ({
                   id="input-service-pickupLocation"
                   component={Select}
                   dataOptions={selectOptions}
-                  parse={v => (v === 'true')}
+                  onChange={handleChange}
                   disabled={disabled}
                 />
               </Col>
@@ -315,6 +349,11 @@ const ServicePointForm = ({
             expanded={sections.locationSection}
             onToggle={handleSectionToggle}
           />
+          <ConfirmPickupLocationChangeModal
+            open={isConfirmPickupLocationChangeModal}
+            onConfirm={onConfirmConfirmPickupLocationChangeModal}
+            onCancel={onCancelConfirmPickupLocationChangeModal}
+          />
         </Pane>
       </Paneset>
     </form>
@@ -328,6 +367,9 @@ ServicePointForm.propTypes = {
   parentMutator: PropTypes.object,
   onCancel: PropTypes.func,
   pristine: PropTypes.bool,
+  location: PropTypes.shape({
+    search: PropTypes.string.isRequired,
+  }).isRequired,
   submitting: PropTypes.bool,
   form: PropTypes.object.isRequired,
 };

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -201,10 +201,12 @@ const ServicePointForm = ({
   };
 
   const handleChange = (e) => {
-    if (isConfirmPickupLocationChangeModalShouldBeVisible(search, e.target.value)) {
+    const value = e.target.value;
+
+    if (isConfirmPickupLocationChangeModalShouldBeVisible(search, value)) {
       setIsConfirmPickupLocationChangeModal(true);
     } else {
-      form.change('pickupLocation', e.target.value === SELECTED_PICKUP_LOCATION_VALUE);
+      form.change('pickupLocation', value === SELECTED_PICKUP_LOCATION_VALUE);
     }
   };
 

--- a/src/settings/ServicePoints/ServicePointForm.test.js
+++ b/src/settings/ServicePoints/ServicePointForm.test.js
@@ -1,0 +1,28 @@
+import {
+  SELECTED_PICKUP_LOCATION_VALUE,
+  UNSELECTED_PICKUP_LOCATION_VALUE,
+  LAYER_EDIT,
+  isConfirmPickupLocationChangeModalShouldBeVisible,
+} from './ServicePointForm';
+
+describe('ServicePointForm', () => {
+  describe('isConfirmPickupLocationChangeModalShouldBeVisible', () => {
+    const OTHER_LAYER = 'other';
+
+    it(`should return true for layer equal "${LAYER_EDIT}" and value "${UNSELECTED_PICKUP_LOCATION_VALUE}"`, () => {
+      expect(isConfirmPickupLocationChangeModalShouldBeVisible(LAYER_EDIT, UNSELECTED_PICKUP_LOCATION_VALUE)).toBe(true);
+    });
+
+    it(`should return false for layer equal "${LAYER_EDIT}" and value "${SELECTED_PICKUP_LOCATION_VALUE}"`, () => {
+      expect(isConfirmPickupLocationChangeModalShouldBeVisible(LAYER_EDIT, SELECTED_PICKUP_LOCATION_VALUE)).toBe(false);
+    });
+
+    it(`should return false for layer not equal "${LAYER_EDIT}"(${OTHER_LAYER}) and value "${UNSELECTED_PICKUP_LOCATION_VALUE}"`, () => {
+      expect(isConfirmPickupLocationChangeModalShouldBeVisible(OTHER_LAYER, UNSELECTED_PICKUP_LOCATION_VALUE)).toBe(false);
+    });
+
+    it(`should return false for layer not equal "${LAYER_EDIT}"(${OTHER_LAYER}) and value "${SELECTED_PICKUP_LOCATION_VALUE}"`, () => {
+      expect(isConfirmPickupLocationChangeModalShouldBeVisible(OTHER_LAYER, SELECTED_PICKUP_LOCATION_VALUE)).toBe(false);
+    });
+  });
+});

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -193,5 +193,10 @@
   "permission.settings.sso": "Settings (tenant): Can maintain SSO settings",
   "permission.settings.location": "Settings (tenant): Can create, edit and remove locations",
   "permission.settings.servicepoints": "Settings (tenant):  Can create, edit and remove service points",
-  "permission.settings.bursar-exports": "Settings (tenant): Bursar admin"
+  "permission.settings.bursar-exports": "Settings (tenant): Bursar admin",
+
+  "settings.confirmPickupLocationChangeModal.title": "Confirm Pickup location change",
+  "settings.confirmPickupLocationChangeModal.message": "Changing this Pickup location from \"Yes\" to \"No\" will remove it from existing Request policies and affect all Circulation rules using the policies.",
+  "settings.confirmPickupLocationChangeModal.button.confirm": "Confirm",
+  "settings.confirmPickupLocationChangeModal.button.cancel": "Back"
 }


### PR DESCRIPTION
## Purpose
Service Point Page - Add Confirm Pickup location change popup message

## Refs
https://issues.folio.org/browse/UITEN-251