### PR TITLE
No errors when inventory-related interfaces are not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-tenant-settings
 
-## IN PROGRESS
+## 8.0.1 (IN PROGRESS)
+
+* [UITEN-266](https://issues.folio.org/browse/UITEN-266) No longer displays non-working inventory-related pages when the inventory interfaces are not present.
 
 ## [8.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.0.0)(2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v7.4.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
     "route": "/tenant-settings",
     "okapiInterfaces": {
       "configuration": "2.0",
-      "location-units": "2.0",
-      "locations": "3.0",
       "login-saml": "2.0",
-      "service-points": "3.0",
       "users": "15.0 16.0"
     },
     "optionalOkapiInterfaces": {
+      "location-units": "2.0",
+      "locations": "3.0",
       "remote-storage-configurations": "1.0",
-      "remote-storage-mappings": "1.0 2.0"
+      "remote-storage-mappings": "1.0 2.0",
+      "service-points": "3.0"
     },
     "permissionSets": [
       {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -61,6 +61,7 @@ class Organization extends React.Component {
             label: <FormattedMessage id="ui-tenant-settings.settings.servicePoints.label" />,
             component: ServicePoints,
             perm: 'ui-tenant-settings.settings.servicepoints.view',
+            iface: 'service-points',
           },
         ],
       },
@@ -72,24 +73,28 @@ class Organization extends React.Component {
             label: <FormattedMessage id="ui-tenant-settings.settings.location.institutions" />,
             component: LocationInstitutions,
             perm: 'ui-tenant-settings.settings.location.view',
+            iface: 'location-units',
           },
           {
             route: 'location-campuses',
             label: <FormattedMessage id="ui-tenant-settings.settings.location.campuses" />,
             component: LocationCampuses,
             perm: 'ui-tenant-settings.settings.location.view',
+            iface: 'location-units',
           },
           {
             route: 'location-libraries',
             label: <FormattedMessage id="ui-tenant-settings.settings.location.libraries" />,
             component: LocationLibraries,
             perm: 'ui-tenant-settings.settings.location.view',
+            iface: 'location-units',
           },
           {
             route: 'location-locations',
             label: <FormattedMessage id="ui-tenant-settings.settings.location.locations" />,
             component: LocationLocations,
             perm: 'ui-tenant-settings.settings.location.view',
+            iface: 'location-units',
           },
         ],
       }
@@ -109,10 +114,18 @@ class Organization extends React.Component {
   */
 
   render() {
+    // If this PR is accepted, we will not need to do this filtering by hand:
+    // https://github.com/folio-org/stripes-smart-components/pull/1401#issuecomment-1771334495
+    // But for now ...
+    const sections = this.sections.map(section => ({
+      label: section.label,
+      pages: section.pages.filter(page => !page.iface || this.props.stripes.hasInterface(page.iface)),
+    }));
+
     return (
       <Settings
         {...this.props}
-        sections={this.sections}
+        sections={sections}
         paneTitle={<FormattedMessage id="ui-tenant-settings.settings.index.paneTitle" />}
       />
     );


### PR DESCRIPTION
We now check for the presence of relevant interfaces at run-time, and no make unsupported settings pages available when the relevant interfaces are not present.

Those interfaces (all to do with inventory) are now marked as optional in the package file.

It will be possible to simplify this code if/when support for the `iface` element is added to the `<Settings>` component, but the present fix does not depend on that future change: see https://github.com/folio-org/stripes-smart-components/pull/1401#issuecomment-1771403292

Fixes UITEN-266.
