### PR TITLE
UITEN-274: Use Save & close button label stripes-component translation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.2.0 (IN PROGRESS)
 
+* [UITEN-274](https://folio-org.atlassian.net/browse/UITEN-274) Use Save & close button label stripes-component translation key.
+
 ## [8.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.1.0)(2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v8.0.0...v8.1.0)
 

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -138,7 +138,7 @@ const ServicePointForm = ({
         buttonStyle="primary mega"
         disabled={(pristine || submitting)}
       >
-        <FormattedMessage id="ui-tenant-settings.settings.general.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
     );
 

--- a/src/settings/ServicePoints/ServicePointFormContainer.test.js
+++ b/src/settings/ServicePoints/ServicePointFormContainer.test.js
@@ -78,7 +78,7 @@ describe('ServicePointFormContainer', () => {
 
     textboxes.forEach((el) => expect(screen.getByRole('textbox', { name: el })).toHaveValue('new value'));
 
-    userEvent.click(screen.getByRole('button', { name: /settings.general.saveAndClose/ }));
+    userEvent.click(screen.getByRole('button', { name: /saveAndClose/ }));
   });
 
   it('should render ServicePointFormContainer select with changed options', () => {

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -18,7 +18,6 @@
 
 
   "settings.general.label": "General",
-  "settings.general.saveAndClose": "Save & close",
 
   "settings.index.paneTitle": "Tenant",
   "settings.bindings.label": "Key bindings",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UITEN-274
We removed local `saveAndClose` label and replace it with `stripes-components.saveAndClose`. Also all related tests updated