### PR TITLE
UITEN-280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.2.0 (IN PROGRESS)
 
 * [UITEN-274](https://folio-org.atlassian.net/browse/UITEN-274) Use Save & close button label stripes-component translation key.
+* [UITEN-280](https://folio-org.atlassian.net/browse/UITEN-280) Conditionally include SSO Settings based on login-saml interface.
 
 ## [8.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.1.0)(2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v8.0.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "route": "/tenant-settings",
     "okapiInterfaces": {
       "configuration": "2.0",
-      "login-saml": "2.0",
       "users": "15.0 16.0"
     },
     "optionalOkapiInterfaces": {
       "location-units": "2.0",
       "locations": "3.0",
+      "login-saml": "2.0",
       "remote-storage-configurations": "1.0",
       "remote-storage-mappings": "1.0 2.0",
       "service-points": "3.0"

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -55,7 +55,7 @@ class Organization extends React.Component {
             label: <FormattedMessage id="ui-tenant-settings.settings.ssoSettings.label" />,
             component: SSOSettings,
             perm: 'ui-tenant-settings.settings.sso.view',
-            disabled: !this.props.stripes.discovery?.interfaces?.['login-saml']
+            iface: 'login-saml'
           },
           {
             route: 'servicePoints',
@@ -120,7 +120,7 @@ class Organization extends React.Component {
     // But for now ...
     const sections = this.sections.map(section => ({
       label: section.label,
-      pages: section.pages.filter(page => (!page.iface || this.props.stripes.hasInterface(page.iface)) && !page.disabled),
+      pages: section.pages.filter(page => !page.iface || this.props.stripes.hasInterface(page.iface)),
     }));
 
     return (

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -55,6 +55,7 @@ class Organization extends React.Component {
             label: <FormattedMessage id="ui-tenant-settings.settings.ssoSettings.label" />,
             component: SSOSettings,
             perm: 'ui-tenant-settings.settings.sso.view',
+            disabled: !this.props.stripes.discovery?.interfaces?.['login-saml']
           },
           {
             route: 'servicePoints',
@@ -119,7 +120,7 @@ class Organization extends React.Component {
     // But for now ...
     const sections = this.sections.map(section => ({
       label: section.label,
-      pages: section.pages.filter(page => !page.iface || this.props.stripes.hasInterface(page.iface)),
+      pages: section.pages.filter(page => (!page.iface || this.props.stripes.hasInterface(page.iface)) && !page.disabled),
     }));
 
     return (

--- a/src/settings/index.test.js
+++ b/src/settings/index.test.js
@@ -8,13 +8,13 @@ import buildStripes from '../../test/jest/__new_mocks__/stripesCore.mock';
 
 import Organization from './index';
 
-let stripes = buildStripes();
+const stripes = buildStripes();
 
 const intl = {
   formatMessage: jest.fn()
 };
 
-let props = {
+const props = {
   stripes,
   intl,
   history: {},
@@ -35,11 +35,11 @@ describe('Organization', () => {
       interfaces: {}
     };
     stripes.setIsAuthenticated = jest.fn();
-    stripes.discovery.interfaces['login-saml'] = null;
+    stripes.hasInterface = jest.fn().mockReturnValue(false);
   });
 
   it('should render SSO Settings when login-saml interface is present', () => {
-    stripes.discovery.interfaces['login-saml'] = '1.0.0';
+    stripes.hasInterface = jest.fn().mockReturnValue(true);
     const { queryByText } = renderWithRouter(<Organization {...props} />);
     expect(queryByText('ui-tenant-settings.settings.ssoSettings.label')).toBeTruthy();
   });

--- a/src/settings/index.test.js
+++ b/src/settings/index.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import '../../test/jest/__mocks__';
+import {
+  renderWithRouter
+} from '../../test/jest/helpers';
+import buildStripes from '../../test/jest/__new_mocks__/stripesCore.mock';
+
+import Organization from './index';
+
+let stripes = buildStripes();
+
+const intl = {
+  formatMessage: jest.fn()
+};
+
+let props = {
+  stripes,
+  intl,
+  history: {},
+  location: {
+    pathname: '/tenant-settings'
+  },
+  match: {
+    path: '/tenant-settings',
+    params: {
+      id: '1'
+    }
+  }
+};
+
+describe('Organization', () => {
+  beforeEach(() => {
+    stripes.discovery = {
+      interfaces: {}
+    };
+    stripes.setIsAuthenticated = jest.fn();
+    stripes.discovery.interfaces['login-saml'] = null;
+  });
+
+  it('should render SSO Settings when login-saml interface is present', () => {
+    stripes.discovery.interfaces['login-saml'] = '1.0.0';
+    const { queryByText } = renderWithRouter(<Organization {...props} />);
+    expect(queryByText('ui-tenant-settings.settings.ssoSettings.label')).toBeTruthy();
+  });
+
+  it('should not render SSO Settings when login-saml interface is not present', () => {
+    const { queryByText } = renderWithRouter(<Organization {...props} />);
+    expect(queryByText('ui-tenant-settings.settings.ssoSettings.label')).toBeNull();
+  });
+});


### PR DESCRIPTION
- [UITEN-280](https://folio-org.atlassian.net/browse/UITEN-280) Conditionally include SSO Settings based on `login-saml` interface.
- Not all FOLIO installations support SSO, so this setting should be suppressed when `login-saml` is not present. 
- This will also suppress `login-saml` from the missing interfaces list on the Software Versions page in Settings, which is expected.