### PR TITLE
UITEN-287 - Add new permission to create, edit and remove reading room access in tenant settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UITEN-274](https://folio-org.atlassian.net/browse/UITEN-274) Use Save & close button label stripes-component translation key.
 * [UITEN-280](https://folio-org.atlassian.net/browse/UITEN-280) Conditionally include SSO Settings based on login-saml interface.
 * [UITEN-286](https://folio-org.atlassian.net/browse/UITEN-286) *BREAKING* Add new interface. Add new permission to view reading room access in tenant settings.
+* [UITEN-287](https://folio-org.atlassian.net/browse/UITEN-287) Add new permission to create, edit and remove reading room access in tenant settings.
 
 ## [8.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.1.0)(2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v8.0.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -225,8 +225,7 @@
           "ui-tenant-settings.settings.reading-room-access.view",
           "reading-room.item.put",
           "reading-room.item.post",
-          "reading-room.item.delete",
-          "settings.tenant-settings.enabled"
+          "reading-room.item.delete"
         ],
         "visible": true
       }

--- a/package.json
+++ b/package.json
@@ -217,6 +217,18 @@
           "settings.tenant-settings.enabled"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "ui-tenant-settings.settings.reading-room-access.all",
+        "displayName": "Settings (tenant): Can create, edit and remove reading room access",
+        "subPermissions": [
+          "ui-tenant-settings.settings.reading-room-access.view",
+          "reading-room.item.put",
+          "reading-room.item.post",
+          "reading-room.item.delete",
+          "settings.tenant-settings.enabled"
+        ],
+        "visible": true
       }
     ]
   },

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -216,6 +216,7 @@
   "permission.settings.servicepoints.view": "Settings (tenant): Can view service points",
   "permission.settings.bursar-exports": "Settings (tenant): Bursar admin",
   "permission.settings.reading-room-access.view": "Settings (tenant): Can view reading room access",
+  "permission.settings.reading-room-access.all": "Settings (tenant): Can create, edit and remove reading room access",
 
   "settings.confirmPickupLocationChangeModal.title": "Confirm Pickup location change",
   "settings.confirmPickupLocationChangeModal.message": "Changing this Pickup location from \"Yes\" to \"No\" will remove it from existing Request policies and affect all Circulation rules using the policies.",


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/UITEN-287 - Add “Settings (tenant): Can create, edit and remove reading room access” permission.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
