### PR TITLE
UITEN-285: Disable edit of Routing service point field (ECS only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [UITEN-282] (https://issues.folio.org/browse/UITEN-282) Reading Room Access (settings): Update reading room.
 * [UITEN-283] (https://issues.folio.org/browse/UITEN-283) Reading Room Access (settings): Delete reading room.
 * [UITEN-281](https://folio-org.atlassian.net/browse/UITEN-281) Add Routing service point option to Service point page(ECS only).
+* [UITEN-285](https://folio-org.atlassian.net/browse/UITEN-285) Disable edit of Routing service point field (ECS only).
 
 ## [8.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.1.0)(2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v8.0.0...v8.1.0)

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -55,6 +55,9 @@ export const SELECTED_ROUTING_SERVICE_POINT_VALUE = 'true';
 export const SELECTED_PICKUP_LOCATION_VALUE = 'true';
 export const UNSELECTED_PICKUP_LOCATION_VALUE = 'false';
 export const LAYER_EDIT = 'layer=edit';
+export const isEcsRequestRoutingDisable = (search) => (
+  search.includes(LAYER_EDIT)
+);
 export const isConfirmPickupLocationChangeModalShouldBeVisible = (search, value) => (
   search.includes(LAYER_EDIT) && value === UNSELECTED_PICKUP_LOCATION_VALUE
 );
@@ -309,7 +312,7 @@ const ServicePointForm = ({
                     component={Select}
                     dataOptions={selectOptions}
                     onChange={handleEcsRequestRoutingChange}
-                    disabled={disabled}
+                    disabled={disabled || isEcsRequestRoutingDisable(search)}
                   />
                 </Col>
               </Row>

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -55,11 +55,11 @@ export const SELECTED_ROUTING_SERVICE_POINT_VALUE = 'true';
 export const SELECTED_PICKUP_LOCATION_VALUE = 'true';
 export const UNSELECTED_PICKUP_LOCATION_VALUE = 'false';
 export const LAYER_EDIT = 'layer=edit';
-export const isEcsRequestRoutingDisable = (search) => (
+export const isLayerEdit = (search) => (
   search.includes(LAYER_EDIT)
 );
 export const isConfirmPickupLocationChangeModalShouldBeVisible = (search, value) => (
-  search.includes(LAYER_EDIT) && value === UNSELECTED_PICKUP_LOCATION_VALUE
+  isLayerEdit(search) && value === UNSELECTED_PICKUP_LOCATION_VALUE
 );
 
 const ServicePointForm = ({
@@ -312,7 +312,7 @@ const ServicePointForm = ({
                     component={Select}
                     dataOptions={selectOptions}
                     onChange={handleEcsRequestRoutingChange}
-                    disabled={disabled || isEcsRequestRoutingDisable(search)}
+                    disabled={disabled || isLayerEdit(search)}
                   />
                 </Col>
               </Row>

--- a/src/settings/ServicePoints/ServicePointForm.test.js
+++ b/src/settings/ServicePoints/ServicePointForm.test.js
@@ -2,20 +2,20 @@ import {
   SELECTED_PICKUP_LOCATION_VALUE,
   UNSELECTED_PICKUP_LOCATION_VALUE,
   LAYER_EDIT,
-  isEcsRequestRoutingDisable,
+  isLayerEdit,
   isConfirmPickupLocationChangeModalShouldBeVisible,
 } from './ServicePointForm';
 
 describe('ServicePointForm', () => {
   const OTHER_LAYER = 'other';
 
-  describe('isEcsRequestRoutingDisable', () => {
+  describe('isLayerEdit', () => {
     it(`should return true for layer equal "${LAYER_EDIT}"`, () => {
-      expect(isEcsRequestRoutingDisable(LAYER_EDIT)).toBe(true);
+      expect(isLayerEdit(LAYER_EDIT)).toBe(true);
     });
 
     it(`should return false for layer not equal "${LAYER_EDIT}"(${OTHER_LAYER})`, () => {
-      expect(isEcsRequestRoutingDisable(OTHER_LAYER)).toBe(false);
+      expect(isLayerEdit(OTHER_LAYER)).toBe(false);
     });
   });
 

--- a/src/settings/ServicePoints/ServicePointForm.test.js
+++ b/src/settings/ServicePoints/ServicePointForm.test.js
@@ -2,13 +2,24 @@ import {
   SELECTED_PICKUP_LOCATION_VALUE,
   UNSELECTED_PICKUP_LOCATION_VALUE,
   LAYER_EDIT,
+  isEcsRequestRoutingDisable,
   isConfirmPickupLocationChangeModalShouldBeVisible,
 } from './ServicePointForm';
 
 describe('ServicePointForm', () => {
-  describe('isConfirmPickupLocationChangeModalShouldBeVisible', () => {
-    const OTHER_LAYER = 'other';
+  const OTHER_LAYER = 'other';
 
+  describe('isEcsRequestRoutingDisable', () => {
+    it(`should return true for layer equal "${LAYER_EDIT}"`, () => {
+      expect(isEcsRequestRoutingDisable(LAYER_EDIT)).toBe(true);
+    });
+
+    it(`should return false for layer not equal "${LAYER_EDIT}"(${OTHER_LAYER})`, () => {
+      expect(isEcsRequestRoutingDisable(OTHER_LAYER)).toBe(false);
+    });
+  });
+
+  describe('isConfirmPickupLocationChangeModalShouldBeVisible', () => {
     it(`should return true for layer equal "${LAYER_EDIT}" and value "${UNSELECTED_PICKUP_LOCATION_VALUE}"`, () => {
       expect(isConfirmPickupLocationChangeModalShouldBeVisible(LAYER_EDIT, UNSELECTED_PICKUP_LOCATION_VALUE)).toBe(true);
     });


### PR DESCRIPTION
## Purpose
Disable edit of Routing service point field (ECS only)

# Refs
https://issues.folio.org/browse/UITEN-285
