### PR TITLE
UITEN-301 - Display Reading room access in alphabetical order on settings page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [UITEN-283] (https://issues.folio.org/browse/UITEN-283) Reading Room Access (settings): Delete reading room.
 * [UITEN-290] (https://issues.folio.org/browse/UITEN-290) Make dependency on mod-reading-rooms optional.
 * [UITEN-298] (https://issues.folio.org/browse/UITEN-298) Update translation ids for reading room.
+* [UITEN-301] (https://issues.folio.org/browse/UITEN-301) Display Reading room access in alphabetical order on settings page.
 
 ## [8.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.1.0)(2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v8.0.0...v8.1.0)

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -52,18 +52,18 @@ class Organization extends React.Component {
             perm: 'ui-tenant-settings.settings.plugins.view',
           },
           {
-            route: 'ssosettings',
-            label: <FormattedMessage id="ui-tenant-settings.settings.ssoSettings.label" />,
-            component: SSOSettings,
-            perm: 'ui-tenant-settings.settings.sso.view',
-            iface: 'login-saml'
-          },
-          {
             route: 'reading-room',
             label: <FormattedMessage id="ui-tenant-settings.settings.reading-room-access.label" />,
             component: ReadingRoomAccess,
             perm: 'ui-tenant-settings.settings.reading-room-access.view',
             iface: 'reading-room'
+          },
+          {
+            route: 'ssosettings',
+            label: <FormattedMessage id="ui-tenant-settings.settings.ssoSettings.label" />,
+            component: SSOSettings,
+            perm: 'ui-tenant-settings.settings.sso.view',
+            iface: 'login-saml'
           },
           {
             route: 'servicePoints',

--- a/src/settings/index.test.js
+++ b/src/settings/index.test.js
@@ -36,10 +36,12 @@ describe('Organization', () => {
     };
     stripes.setIsAuthenticated = jest.fn();
     stripes.hasInterface = jest.fn().mockReturnValue(false);
+    stripes.hasPerm = jest.fn().mockReturnValue(false);
   });
 
   it('should render SSO Settings when login-saml interface is present', () => {
     stripes.hasInterface = jest.fn().mockReturnValue(true);
+    stripes.hasPerm = jest.fn().mockReturnValue(true);
     const { queryByText } = renderWithRouter(<Organization {...props} />);
     expect(queryByText('ui-tenant-settings.settings.ssoSettings.label')).toBeTruthy();
   });
@@ -47,5 +49,24 @@ describe('Organization', () => {
   it('should not render SSO Settings when login-saml interface is not present', () => {
     const { queryByText } = renderWithRouter(<Organization {...props} />);
     expect(queryByText('ui-tenant-settings.settings.ssoSettings.label')).toBeNull();
+  });
+
+  it('should render Reading room access when associated permission and interface are present', () => {
+    stripes.hasInterface = jest.fn().mockReturnValue(true);
+    stripes.hasPerm = jest.fn().mockReturnValue(true);
+    const { queryByText } = renderWithRouter(<Organization {...props} />);
+    expect(queryByText('ui-tenant-settings.settings.reading-room-access.label')).toBeTruthy();
+  });
+
+  it('should not render Reading room access when ui-tenant-settings.settings.reading-room-access.view permission is not present', () => {
+    stripes.hasInterface = jest.fn().mockReturnValue(true);
+    const { queryByText } = renderWithRouter(<Organization {...props} />);
+    expect(queryByText('ui-tenant-settings.settings.reading-room-access.label')).toBeNull();
+  });
+
+  it('should not render Reading room access when reading-room interface is not present', () => {
+    stripes.hasPerm = jest.fn().mockReturnValue(true);
+    const { queryByText } = renderWithRouter(<Organization {...props} />);
+    expect(queryByText('ui-tenant-settings.settings.reading-room-access.label')).toBeNull();
   });
 });

--- a/test/jest/__new_mocks__/stripesCore.mock.js
+++ b/test/jest/__new_mocks__/stripesCore.mock.js
@@ -10,7 +10,7 @@ const buildStripes = (otherProperties = {}) => ({
   },
   currency: 'USD',
   hasInterface: () => true,
-  hasPerm: jest.fn(() => true),
+  hasPerm: () => true,
   locale: 'en-US',
   logger: {
     log: () => { },


### PR DESCRIPTION
## Purpose
[UITEN-301](https://folio-org.atlassian.net/browse/UITEN-301) - Display Reading room access in alphabetical order on settings page.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Screencast
<img width="955" alt="image" src="https://github.com/folio-org/ui-tenant-settings/assets/104053200/61f93f47-6195-4d48-80f3-430658850ff2">



## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
