### PR TITLE
UITEN-304 - Provide case insensitive sorted data to edit record, field components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [UITEN-301] (https://issues.folio.org/browse/UITEN-301) Display Reading room access in alphabetical order on settings page.
 * [UITEN-212](https://folio-org.atlassian.net/browse/UITEN-212) Permission changes for service point management.
 * [UITEN-299](https://folio-org.atlassian.net/browse/UITEN-299) Rewrite class components to functional ones (ui-tenant-settings module).
+* [UITEN-304](https://folio-org.atlassian.net/browse/UITEN-304) Provide case insensitive sorted data to edit record, field components.
 
 ## [8.1.0](https://github.com/folio-org/ui-tenant-settings/tree/v8.1.0)(2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-tenant-settings/compare/v8.0.0...v8.1.0)

--- a/src/settings/ReadingRoomAccess/ReadingRoomAccess.js
+++ b/src/settings/ReadingRoomAccess/ReadingRoomAccess.js
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import _ from 'lodash';
+import sortBy from 'lodash/sortBy';
+import get from 'lodash/get';
 
 import {
   TitleManager,
@@ -31,13 +32,13 @@ const ReadingRoomAccess = (props) => {
   const { resources } = props;
 
   // service points defined in the tenant
-  const servicePoints = _.get(resources, ['RRAServicePoints', 'records', 0, 'servicepoints'], []);
+  const servicePoints = get(resources, ['RRAServicePoints', 'records', 0, 'servicepoints'], []);
   /**
    * A reading room can have more than one service points assigned to it.
    * but a servicepoint cannot be mapped to more than one reading room
    */
   const sps = [];
-  const rrs = _.get(resources, ['values', 'records']);
+  const rrs = get(resources, ['values', 'records']);
   rrs.forEach(rr => {
     const asp = rr.servicePoints || [];
     asp.forEach(s => {
@@ -110,7 +111,7 @@ const ReadingRoomAccess = (props) => {
         formatter={formatter}
         translations={translations}
         editable={editable}
-        fieldComponents={getFieldComponents(fieldLabels, options, resources?.values?.records)}
+        fieldComponents={getFieldComponents(fieldLabels, options, sortBy(resources?.values?.records, [t => t.name && t.name.toLowerCase()]))}
         validate={validate}
         formType="final-form"
       />

--- a/src/settings/ReadingRoomAccess/ReadingRoomAccess.test.js
+++ b/src/settings/ReadingRoomAccess/ReadingRoomAccess.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Form } from 'react-final-form';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { runAxeTest } from '@folio/stripes-testing';
 
@@ -10,6 +11,77 @@ import ReadingRoomAccess from './ReadingRoomAccess';
 import '../../../test/jest/__mocks__';
 import { mockHasPerm } from '../../../test/jest/__mocks__/stripesCore.mock';
 
+jest.mock('../../hooks/useServicePoints', () => ({
+  useServicePoints: jest.fn(() => ({
+    servicePoints: [
+      {
+        'id': 'c4c90014-c8c9-4ade-8f24-b5e313319f4b',
+        'name': 'Circ Desk 2',
+        'code': 'cd2',
+        'discoveryDisplayName': 'Circulation Desk -- Back Entrance',
+        'pickupLocation': true,
+        'holdShelfExpiryPeriod': {
+          'duration': 5,
+          'intervalId': 'Days'
+        },
+        'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
+        'staffSlips': [],
+        'metadata': {
+          'createdDate': '2024-04-23T01:53:59.590+00:00',
+          'updatedDate': '2024-04-23T01:53:59.590+00:00'
+        }
+      },
+      {
+        'id': '3a40852d-49fd-4df2-a1f9-6e2641a6e91f',
+        'name': 'Circ Desk 1',
+        'code': 'cd1',
+        'discoveryDisplayName': 'Circulation Desk -- Hallway',
+        'pickupLocation': true,
+        'holdShelfExpiryPeriod': {
+          'duration': 3,
+          'intervalId': 'Weeks'
+        },
+        'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
+        'staffSlips': [],
+        'metadata': {
+          'createdDate': '2024-04-23T01:53:59.598+00:00',
+          'updatedDate': '2024-04-23T01:53:59.598+00:00'
+        }
+      },
+      {
+        'id': '7c5abc9f-f3d7-4856-b8d7-6712462ca007',
+        'name': 'Online',
+        'code': 'Online',
+        'discoveryDisplayName': 'Online',
+        'shelvingLagTime': 0,
+        'pickupLocation': false,
+        'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
+        'staffSlips': [],
+        'metadata': {
+          'createdDate': '2024-04-23T01:53:59.593+00:00',
+          'updatedDate': '2024-04-23T01:53:59.593+00:00'
+        }
+      },
+      {
+        'id': '9d1b77e8-f02e-4b7f-b296-3f2042ddac54',
+        'name': 'DCB',
+        'code': '000',
+        'discoveryDisplayName': 'DCB',
+        'pickupLocation': true,
+        'holdShelfExpiryPeriod': {
+          'duration': 3,
+          'intervalId': 'Days'
+        },
+        'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
+        'staffSlips': [],
+        'metadata': {
+          'createdDate': '2024-04-23T01:56:03.899+00:00',
+          'updatedDate': '2024-04-23T01:56:03.899+00:00'
+        }
+      }
+    ]
+  })),
+}));
 const mutatorPutMock = jest.fn(() => Promise.resolve());
 const mutatorMock = {
   values: {
@@ -83,92 +155,17 @@ const resourcesMock = {
       }
     ],
   },
-  RRAServicePoints: {
-    'hasLoaded': true,
-    'isPending': false,
-    'failed': false,
-    'records': [
-      {
-        'servicepoints': [
-          {
-            'id': 'c4c90014-c8c9-4ade-8f24-b5e313319f4b',
-            'name': 'Circ Desk 2',
-            'code': 'cd2',
-            'discoveryDisplayName': 'Circulation Desk -- Back Entrance',
-            'pickupLocation': true,
-            'holdShelfExpiryPeriod': {
-              'duration': 5,
-              'intervalId': 'Days'
-            },
-            'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
-            'staffSlips': [],
-            'metadata': {
-              'createdDate': '2024-04-23T01:53:59.590+00:00',
-              'updatedDate': '2024-04-23T01:53:59.590+00:00'
-            }
-          },
-          {
-            'id': '3a40852d-49fd-4df2-a1f9-6e2641a6e91f',
-            'name': 'Circ Desk 1',
-            'code': 'cd1',
-            'discoveryDisplayName': 'Circulation Desk -- Hallway',
-            'pickupLocation': true,
-            'holdShelfExpiryPeriod': {
-              'duration': 3,
-              'intervalId': 'Weeks'
-            },
-            'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
-            'staffSlips': [],
-            'metadata': {
-              'createdDate': '2024-04-23T01:53:59.598+00:00',
-              'updatedDate': '2024-04-23T01:53:59.598+00:00'
-            }
-          },
-          {
-            'id': '7c5abc9f-f3d7-4856-b8d7-6712462ca007',
-            'name': 'Online',
-            'code': 'Online',
-            'discoveryDisplayName': 'Online',
-            'shelvingLagTime': 0,
-            'pickupLocation': false,
-            'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
-            'staffSlips': [],
-            'metadata': {
-              'createdDate': '2024-04-23T01:53:59.593+00:00',
-              'updatedDate': '2024-04-23T01:53:59.593+00:00'
-            }
-          },
-          {
-            'id': '9d1b77e8-f02e-4b7f-b296-3f2042ddac54',
-            'name': 'DCB',
-            'code': '000',
-            'discoveryDisplayName': 'DCB',
-            'pickupLocation': true,
-            'holdShelfExpiryPeriod': {
-              'duration': 3,
-              'intervalId': 'Days'
-            },
-            'holdShelfClosedLibraryDateManagement': 'Keep_the_current_due_date',
-            'staffSlips': [],
-            'metadata': {
-              'createdDate': '2024-04-23T01:56:03.899+00:00',
-              'updatedDate': '2024-04-23T01:56:03.899+00:00'
-            }
-          }
-        ],
-        'totalRecords': 4
-      }
-    ],
-  }
 };
 
 const renderReadingRoomAccess = (props) => renderWithRouter(
-  <Form
-    onSubmit={() => {}}
-    render={() => (
-      <ReadingRoomAccess {...props} />
-    )}
-  />
+  <QueryClientProvider client={new QueryClient()}>
+    <Form
+      onSubmit={() => {}}
+      render={() => (
+        <ReadingRoomAccess {...props} />
+      )}
+    />
+  </QueryClientProvider>
 );
 
 describe('Reading Room Access', () => {

--- a/src/settings/ReadingRoomAccess/constant.js
+++ b/src/settings/ReadingRoomAccess/constant.js
@@ -4,3 +4,5 @@ export const readingRoomAccessColumns = {
   ISPUBLIC: 'isPublic',
   SERVICEPOINTS: 'servicePoints',
 };
+
+export const readingRoomsLimit = 25;


### PR DESCRIPTION
## Purpose
[UITEN-304](https://folio-org.atlassian.net/browse/UITEN-304) - Reading room records checkboxes change state to opposite when edited

## Approach

1. Reading rooms data is rendered on tenant settings page using ControlledVocab from stripes-smart-components.

In the hierarchy of rendering of components to render the list, ControlledVocab used case insensitive sort in [EditableList](https://github.com/folio-org/stripes-smart-components/blob/master/lib/EditableList/EditableList.js#L63).
This case-insensitive sort was not leveraged in the prop for `fieldComponents`.
This has been now added in order to address this bug.

2. the limit param has been modified to 25 as typically there would be maximum 25 reading rooms.
3. Some refactored was achieved.



## Screencast
![2TYVs359DY](https://github.com/user-attachments/assets/2fddc52f-3286-43e9-a8b8-c797c3bcca41)

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
