### PR TITLE
Fix code to pass ESLint successfully.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "extends": ["@folio/eslint-config-stripes"],
   "parser": "@babel/eslint-parser",
+  "rules": {
+    "import/prefer-default-export": "off"
+  },
   "overrides": [
     {
       "files": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.1.0 (IN PROGRESS)
 
+* [UITEN-316](https://folio-org.atlassian.net/browse/UITEN-316) Fix code to pass ESLint successfully.
+
 ## [9.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v9.0.0)(2024-10-30)
 
 * [UITEN-274](https://folio-org.atlassian.net/browse/UITEN-274) Use Save & close button label stripes-component translation key.

--- a/src/settings/LocationLocations/LocationForm/RemoteStorageField.js
+++ b/src/settings/LocationLocations/LocationForm/RemoteStorageField.js
@@ -36,7 +36,7 @@ export const RemoteStorageField = ({ initialValues, checkLocationHasHoldingsOrIt
       setIsReadOnly(true);
       checkLocationHasHoldingsOrItems(locationId).then(setIsReadOnly);
     },
-    [locationId, noInterfaces]
+    [locationId, noInterfaces] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   if (noInterfaces) return null;

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -76,7 +76,7 @@ const ServicePointForm = ({
   const [isConfirmPickupLocationChangeModal, setIsConfirmPickupLocationChangeModal] = useState(false);
   const stripes = useStripes();
   const intl = useIntl();
-  const CViewMetaData = useMemo(() => stripes.connect(ViewMetaData), []);
+  const CViewMetaData = useMemo(() => stripes.connect(ViewMetaData), []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const servicePoint = initialValues || {};
   const locations = servicePoint.id

--- a/src/settings/ServicePoints/ServicePointFormContainer.js
+++ b/src/settings/ServicePoints/ServicePointFormContainer.js
@@ -36,7 +36,7 @@ const ServicePointFormContainer = ({
 
   useEffect(() => {
     setInitialValues(getServicePoint());
-  }, [servicePoint.id, parentResources.staffSlips.hasLoaded]);
+  }, [servicePoint.id, parentResources.staffSlips.hasLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const transformStaffSlipsData = useCallback((staffSlips) => {
     const currentSlips = parentResources?.staffSlips?.records || [];

--- a/test/jest/__mocks__/stripesCore.mock.js
+++ b/test/jest/__mocks__/stripesCore.mock.js
@@ -92,9 +92,12 @@ const mockStripesCore = {
   },
 
   // eslint-disable-next-line react/prop-types
-  Pluggable: props => <><button onClick={props.entityTypeDataSource}>Get query</button>
-    <button onClick={props.cancelQueryDataSource}>Cancel query</button>
-  </>,
+  Pluggable: props => (
+    <>
+      <button type="button" onClick={props.entityTypeDataSource}>Get query</button>
+      <button type="button" onClick={props.cancelQueryDataSource}>Cancel query</button>
+    </>
+  ),
 
   // eslint-disable-next-line react/prop-types
   IfPermission: jest.fn(props => <>{props.children}</>),


### PR DESCRIPTION
Three-pronged approach:
* I disabled the `import/prefer-default-export` rule, since this module consistently uses a different style which is actually just fine.
* In the places where we had `react-hooks/exhaustive-deps` I have simply marked those lines with an `eslint-disable` comment, since my experience adding or removing dependencies to a hook can have subtle consequences that I'm not in a position to deal with right now. I marked each one individually rather than just disabling the rule, since each such warning _may_ be pointing out an actual bug, so someone ought to revisit these at some point.
* I simply fixed the remaining errors, such as missing `type` attributes in `<button>`s.

Fix UITEN-316.