### PR TITLE
[UITEN-328] Service points: support `defaultCheckInActionForUseAtLocation` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UITEN-327](https://folio-org.atlassian.net/browse/UITEN-327) Invalidate queries after updating location
 * [UITEN-330](https://folio-org.atlassian.net/browse/UITEN-330) *BREAKING* Refactor locale settings handling.
 * [UITEN-326](https://folio-org.atlassian.net/browse/UITEN-326) Settings > Tenant > Add Tenant application icon.
+* [UITEN-328](https://folio-org.atlassian.net/browse/UITEN-328) Settings > Tenant > Service points: view and edit the new `defaultCheckInActionForUseAtLocation` field. Requires v3.5 of the `service-points` interface.
 
 ## [10.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v10.0.0)(2025-03-12)
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "login-saml": "2.0",
       "remote-storage-configurations": "1.0",
       "remote-storage-mappings": "1.0 2.0",
-      "service-points": "3.0",
+      "service-points": "3.5",
       "reading-room": "1.0"
     },
     "permissionSets": [

--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
   "scripts": {
     "start": "yarn stripes serve",
     "lint": "eslint .",
+    "qlint": "eslint -f unix --rule '{\"react/forbid-prop-types\":\"off\"}' .",
     "test:unit": "jest --ci --coverage",
     "test": "yarn run test:unit",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",

--- a/src/settings/ServicePoints/ServicePointDetail.js
+++ b/src/settings/ServicePoints/ServicePointDetail.js
@@ -5,7 +5,7 @@ import {
   injectIntl,
   FormattedMessage,
 } from 'react-intl';
-import { Accordion, Col, ExpandAllButton, KeyValue, Row } from '@folio/stripes/components';
+import { Accordion, Col, ExpandAllButton, KeyValue, NoValue, Row } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 
 import { TitleManager } from '@folio/stripes/core';
@@ -13,6 +13,14 @@ import LocationList from './LocationList';
 import StaffSlipList from './StaffSlipList';
 import { intervalPeriods } from '../../constants';
 import { closedLibraryDateManagementMapping } from './constants';
+
+function renderCheckinAction(action) {
+  if (!action) {
+    return <NoValue />;
+  }
+  return <FormattedMessage id={`ui-tenant-settings.settings.servicePoints.defaultCheckinAction.${action}`} />;
+}
+
 
 class ServicePointDetail extends React.Component {
   static propTypes = {
@@ -171,6 +179,14 @@ class ServicePointDetail extends React.Component {
               </>
             )
           }
+            <Row>
+              <Col xs={12} data-test-default-action>
+                <KeyValue
+                  label={<FormattedMessage id="ui-tenant-settings.settings.servicePoints.defaultCheckinAction" />}
+                  value={renderCheckinAction(servicePoint.defaultCheckInActionForUseAtLocation)}
+                />
+              </Col>
+            </Row>
             <StaffSlipList
               servicePoint={servicePoint}
               staffSlips={staffSlips}

--- a/src/settings/ServicePoints/ServicePointForm.js
+++ b/src/settings/ServicePoints/ServicePointForm.js
@@ -96,6 +96,10 @@ const ServicePointForm = ({
       value: true
     }
   ];
+  const defaultActionOptions = ['Keep_on_hold_shelf', 'Close_loan_and_return_item', 'Ask_for_action'].map(key => ({
+    label: intl.formatMessage({ id: `ui-tenant-settings.settings.servicePoints.defaultCheckinAction.${key}` }),
+    value: key
+  }));
   const periods = intervalPeriods.map(ip => (
     {
       ...ip,
@@ -343,6 +347,19 @@ const ServicePointForm = ({
                 </>
               )
             }
+            <Row>
+              <Col xs={4}>
+                <Field
+                  data-test-default-action
+                  label={<FormattedMessage id="ui-tenant-settings.settings.servicePoints.defaultCheckinAction" />}
+                  name="defaultCheckInActionForUseAtLocation"
+                  id="input-service-defaultCheckInActionForUseAtLocation"
+                  component={Select}
+                  dataOptions={defaultActionOptions}
+                  disabled={disabled}
+                />
+              </Col>
+            </Row>
             <StaffSlipEditList staffSlips={staffSlips} />
           </Accordion>
           <LocationList

--- a/translations/ui-tenant-settings/en.json
+++ b/translations/ui-tenant-settings/en.json
@@ -43,6 +43,10 @@
   "settings.saml.validate.idpUrl": "This is not a valid Identity Provider URL",
 
   "settings.servicePoints.holdShelfClosedLibraryDateManagement": "Closed library date management for hold shelf expiration date calculation",
+  "settings.servicePoints.defaultCheckinAction": "Default check-in action for use at location",
+  "settings.servicePoints.defaultCheckinAction.Keep_on_hold_shelf": "Keep on hold shelf",
+  "settings.servicePoints.defaultCheckinAction.Close_loan_and_return_item": "Close loan and return item",
+  "settings.servicePoints.defaultCheckinAction.Ask_for_action": "Ask for action",
   "settings.servicePoints.holdShelfClosedLibraryDateManagement.keepTheOriginalDate": "Keep the original date",
   "settings.servicePoints.holdShelfClosedLibraryDateManagement.moveToTheEndOfThePreviousOpenDay": "Move to the end of the previous open day",
   "settings.servicePoints.holdShelfClosedLibraryDateManagement.moveToTheEndOfTheNextOpenDay": "Move to the end of the next open day",


### PR DESCRIPTION
In Settings > Tenant > Service points: the detail page and edit form include support for the new `defaultCheckInActionForUseAtLocation` field, added to mod-inventory-storage in https://github.com/folio-org/mod-inventory-storage/pull/1212

Requires v3.5 of the `service-points` interface.