### PR TITLE
UITEN-343 Trim leading/trailing whitespace from the service point name on save so it can be assigned to a location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.1.0 (IN PROGRESS)
 
 * [UITEN-345](https://folio-org.atlassian.net/browse/UITEN-345) Unexpected blank space in 'Settings' -> 'Language and localization'
+* [UITEN-343](https://folio-org.atlassian.net/browse/UITEN-343) Trim leading/trailing whitespace from the service point name on save so it can be assigned to a location.
 
 ## [11.0.0](https://github.com/folio-org/ui-tenant-settings/tree/v11.0.0)(2026-04-16)
 

--- a/src/settings/ServicePoints/ServicePointFormContainer.js
+++ b/src/settings/ServicePoints/ServicePointFormContainer.js
@@ -51,6 +51,11 @@ const ServicePointFormContainer = ({
   const onSubmit = useCallback((values) => {
     const data = cloneDeep(values);
 
+    // Trim the name so a service point is never saved with leading/trailing
+    if (typeof data.name === 'string') {
+      data.name = data.name.trim();
+    }
+
     const { locationIds, staffSlips } = data;
 
     if (locationIds) {

--- a/src/settings/ServicePoints/ServicePointFormContainer.test.js
+++ b/src/settings/ServicePoints/ServicePointFormContainer.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import '../../../test/jest/__mocks__';
@@ -22,6 +22,27 @@ const renderServicePointFormContainer = () => {
       parentResources={parentResourcesMock}
       initialValues={{ staffSlips }}
       parentMutator={parentMutatorMock}
+    />
+  );
+
+  return renderWithRouter(renderWithReduxForm(component));
+};
+
+const uniqueParentMutator = {
+  ...parentMutatorMock,
+  uniquenessValidator: {
+    ...parentMutatorMock.uniquenessValidator,
+    GET: jest.fn(() => Promise.resolve([])),
+  },
+};
+
+const renderSubmittableServicePointFormContainer = () => {
+  const component = () => (
+    <ServicePointFormContainer
+      onSave={onSave}
+      parentResources={parentResourcesMock}
+      initialValues={{ staffSlips }}
+      parentMutator={uniqueParentMutator}
     />
   );
 
@@ -79,6 +100,20 @@ describe('ServicePointFormContainer', () => {
     textboxes.forEach((el) => expect(screen.getByRole('textbox', { name: el })).toHaveValue('new value'));
 
     userEvent.click(screen.getByRole('button', { name: /saveAndClose/ }));
+  });
+
+  it('should trim leading and trailing whitespace from the name before saving', async () => {
+    onSave.mockClear();
+    renderSubmittableServicePointFormContainer();
+
+    userEvent.type(screen.getByRole('textbox', { name: /settings.servicePoints.name/ }), '  Circ Desk X  ');
+    userEvent.type(screen.getByRole('textbox', { name: /settings.servicePoints.code/ }), 'cdx');
+    userEvent.type(screen.getByRole('textbox', { name: /settings.servicePoints.discoveryDisplayName/ }), 'Display X');
+
+    userEvent.click(screen.getByRole('button', { name: /saveAndClose/ }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].name).toBe('Circ Desk X');
   });
 
   it('should render ServicePointFormContainer select with changed options', () => {


### PR DESCRIPTION
Trim the service point name at the source in `ServicePointFormContainer.onSubmit`, before the payload is sent, so a service point is never saved with surrounding whitespace. This covers both creating and editing a service point (the same form handles both), so re-saving an existing service point also repairs previously stored bad data. Once the stored name has no surrounding whitespace, the name-based lookup on the location form matches and the location saves successfully. 

Refs: [UITEN-343](https://folio-org.atlassian.net/browse/UITEN-343)