### PR TITLE
UITEN-343 Normalize the name so a service point is never saved with leading/trailing whitespace or repeated spaces between words

### DIFF
--- a/src/settings/ServicePoints/ServicePointFormContainer.js
+++ b/src/settings/ServicePoints/ServicePointFormContainer.js
@@ -51,9 +51,10 @@ const ServicePointFormContainer = ({
   const onSubmit = useCallback((values) => {
     const data = cloneDeep(values);
 
-    // Trim the name so a service point is never saved with leading/trailing
+    // Normalize the name so a service point is never saved with leading/trailing
+    // whitespace or repeated spaces between words.
     if (typeof data.name === 'string') {
-      data.name = data.name.trim();
+      data.name = data.name.trim().replace(/\s+/g, ' ');
     }
 
     const { locationIds, staffSlips } = data;

--- a/src/settings/ServicePoints/ServicePointFormContainer.test.js
+++ b/src/settings/ServicePoints/ServicePointFormContainer.test.js
@@ -116,6 +116,20 @@ describe('ServicePointFormContainer', () => {
     expect(onSave.mock.calls[0][0].name).toBe('Circ Desk X');
   });
 
+  it('should collapse repeated whitespace inside the name before saving', async () => {
+    onSave.mockClear();
+    renderSubmittableServicePointFormContainer();
+
+    userEvent.type(screen.getByRole('textbox', { name: /settings.servicePoints.name/ }), 'Name    with  extra    string');
+    userEvent.type(screen.getByRole('textbox', { name: /settings.servicePoints.code/ }), 'cdx');
+    userEvent.type(screen.getByRole('textbox', { name: /settings.servicePoints.discoveryDisplayName/ }), 'Display X');
+
+    userEvent.click(screen.getByRole('button', { name: /saveAndClose/ }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0].name).toBe('Name with extra string');
+  });
+
   it('should render ServicePointFormContainer select with changed options', () => {
     renderServicePointFormContainer();
 


### PR DESCRIPTION
Additional fix for https://github.com/folio-org/ui-tenant-settings/pull/505, extra spaces inside world also have to be replaced.